### PR TITLE
Fix all ESLint errors to pass CI workflow

### DIFF
--- a/src/components/BookmarkedQuestions.test.tsx
+++ b/src/components/BookmarkedQuestions.test.tsx
@@ -76,10 +76,10 @@ vi.mock('@/hooks/useGlossaryTerms', () => ({
 
 vi.mock('framer-motion', () => ({
   motion: {
-    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-    p: ({ children, ...props }: any) => <p {...props}>{children}</p>,
+    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement> & { children?: React.ReactNode }) => <div {...props}>{children}</div>,
+    p: ({ children, ...props }: React.HTMLAttributes<HTMLParagraphElement> & { children?: React.ReactNode }) => <p {...props}>{children}</p>,
   },
-  AnimatePresence: ({ children }: any) => <>{children}</>,
+  AnimatePresence: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
 }));
 
 const createTestQueryClient = () =>

--- a/src/components/ExamSessionMap.tsx
+++ b/src/components/ExamSessionMap.tsx
@@ -4,7 +4,7 @@ import 'leaflet/dist/leaflet.css';
 import type { ExamSession } from '@/hooks/useExamSessions';
 
 // Fix for default marker icons in Leaflet with bundlers
-delete (L.Icon.Default.prototype as any)._getIconUrl;
+delete (L.Icon.Default.prototype as unknown as { _getIconUrl?: unknown })._getIconUrl;
 L.Icon.Default.mergeOptions({
   iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon-2x.png',
   iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png',

--- a/src/components/PracticeTest.test.tsx
+++ b/src/components/PracticeTest.test.tsx
@@ -84,10 +84,10 @@ vi.mock('@/hooks/useGlossaryTerms', () => ({
 
 vi.mock('framer-motion', () => ({
   motion: {
-    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-    p: ({ children, ...props }: any) => <p {...props}>{children}</p>,
+    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement> & { children?: React.ReactNode }) => <div {...props}>{children}</div>,
+    p: ({ children, ...props }: React.HTMLAttributes<HTMLParagraphElement> & { children?: React.ReactNode }) => <p {...props}>{children}</p>,
   },
-  AnimatePresence: ({ children }: any) => <>{children}</>,
+  AnimatePresence: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
 }));
 
 vi.mock('sonner', () => ({

--- a/src/components/ProfileModal.tsx
+++ b/src/components/ProfileModal.tsx
@@ -51,8 +51,8 @@ export function ProfileModal({
       if (error) throw error;
       toast.success("Display name updated successfully");
       onProfileUpdate();
-    } catch (error: any) {
-      toast.error(error.message || "Failed to update display name");
+    } catch (error: unknown) {
+      toast.error(error instanceof Error ? error.message : "Failed to update display name");
     } finally {
       setIsUpdatingName(false);
     }
@@ -81,8 +81,8 @@ export function ProfileModal({
       if (error) throw error;
       toast.success("Verification email sent! Check your new email inbox to confirm the change.");
       setNewEmail("");
-    } catch (error: any) {
-      toast.error(error.message || "Failed to update email");
+    } catch (error: unknown) {
+      toast.error(error instanceof Error ? error.message : "Failed to update email");
     } finally {
       setIsUpdatingEmail(false);
     }
@@ -101,8 +101,8 @@ export function ProfileModal({
       });
       if (error) throw error;
       toast.success("Password reset email sent! Check your inbox.");
-    } catch (error: any) {
-      toast.error(error.message || "Failed to send password reset email");
+    } catch (error: unknown) {
+      toast.error(error instanceof Error ? error.message : "Failed to send password reset email");
     } finally {
       setIsResettingPassword(false);
     }
@@ -132,9 +132,9 @@ export function ProfileModal({
       toast.success("Account and all data deleted successfully");
       onOpenChange(false);
       navigate("/");
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Account deletion failed:', error);
-      toast.error(error.message || "Failed to delete account");
+      toast.error(error instanceof Error ? error.message : "Failed to delete account");
     } finally {
       setIsDeleting(false);
     }

--- a/src/components/QuestionCard.test.tsx
+++ b/src/components/QuestionCard.test.tsx
@@ -33,9 +33,9 @@ vi.mock('@/hooks/useGlossaryTerms', () => ({
 
 vi.mock('framer-motion', () => ({
   motion: {
-    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement> & { children?: React.ReactNode }) => <div {...props}>{children}</div>,
   },
-  AnimatePresence: ({ children }: any) => <>{children}</>,
+  AnimatePresence: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
 }));
 
 const mockQuestion: Question = {

--- a/src/components/RandomPractice.test.tsx
+++ b/src/components/RandomPractice.test.tsx
@@ -83,10 +83,10 @@ vi.mock('@/hooks/useGlossaryTerms', () => ({
 
 vi.mock('framer-motion', () => ({
   motion: {
-    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-    p: ({ children, ...props }: any) => <p {...props}>{children}</p>,
+    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement> & { children?: React.ReactNode }) => <div {...props}>{children}</div>,
+    p: ({ children, ...props }: React.HTMLAttributes<HTMLParagraphElement> & { children?: React.ReactNode }) => <p {...props}>{children}</p>,
   },
-  AnimatePresence: ({ children }: any) => <>{children}</>,
+  AnimatePresence: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
 }));
 
 const createTestQueryClient = () =>

--- a/src/components/SubelementPractice.test.tsx
+++ b/src/components/SubelementPractice.test.tsx
@@ -92,17 +92,17 @@ vi.mock('@/hooks/useGlossaryTerms', () => ({
 
 vi.mock('framer-motion', () => ({
   motion: {
-    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-    p: ({ children, ...props }: any) => <p {...props}>{children}</p>,
-    button: ({ children, onClick, ...props }: any) => (
+    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement> & { children?: React.ReactNode }) => <div {...props}>{children}</div>,
+    p: ({ children, ...props }: React.HTMLAttributes<HTMLParagraphElement> & { children?: React.ReactNode }) => <p {...props}>{children}</p>,
+    button: ({ children, onClick, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement> & { children?: React.ReactNode }) => (
       <button onClick={onClick} {...props}>{children}</button>
     ),
   },
-  AnimatePresence: ({ children }: any) => <>{children}</>,
+  AnimatePresence: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
 }));
 
 vi.mock('@/components/TopicLanding', () => ({
-  TopicLanding: ({ onStartPractice }: any) => (
+  TopicLanding: ({ onStartPractice }: { onStartPractice: () => void }) => (
     <div data-testid="topic-landing">
       <button onClick={onStartPractice}>Start Practice</button>
     </div>

--- a/src/components/SubelementPractice.tsx
+++ b/src/components/SubelementPractice.tsx
@@ -81,7 +81,9 @@ export function SubelementPractice({
     return Object.keys(questionsBySubelement).sort();
   }, [questionsBySubelement]);
 
-  const currentQuestions = selectedSubelement ? questionsBySubelement[selectedSubelement] || [] : [];
+  const currentQuestions = useMemo(() => {
+    return selectedSubelement ? questionsBySubelement[selectedSubelement] || [] : [];
+  }, [selectedSubelement, questionsBySubelement]);
 
   const getRandomQuestion = useCallback((excludeIds: string[] = []): Question | null => {
     if (currentQuestions.length === 0) return null;

--- a/src/components/admin/AdminQuestions.tsx
+++ b/src/components/admin/AdminQuestions.tsx
@@ -289,8 +289,8 @@ export function AdminQuestions({
       }
       setNewLinkUrl("");
       toast.success("Link added successfully");
-    } catch (error: any) {
-      toast.error("Failed to add link: " + error.message);
+    } catch (error: unknown) {
+      toast.error("Failed to add link: " + (error instanceof Error ? error.message : String(error)));
     } finally {
       setIsAddingLink(false);
     }
@@ -320,8 +320,8 @@ export function AdminQuestions({
       });
       setEditLinks(prev => prev.filter(l => l.url !== url));
       toast.success("Link removed successfully");
-    } catch (error: any) {
-      toast.error("Failed to remove link: " + error.message);
+    } catch (error: unknown) {
+      toast.error("Failed to remove link: " + (error instanceof Error ? error.message : String(error)));
     }
   };
   const resetForm = () => {
@@ -398,8 +398,8 @@ export function AdminQuestions({
       setNewLinks(prev => [...prev, linkData]);
       setNewLinkUrlForAdd("");
       toast.success("Link added");
-    } catch (error: any) {
-      toast.error("Failed to add link: " + error.message);
+    } catch (error: unknown) {
+      toast.error("Failed to add link: " + (error instanceof Error ? error.message : String(error)));
     } finally {
       setIsAddingLinkForNew(false);
     }

--- a/src/components/admin/AdminStats.tsx
+++ b/src/components/admin/AdminStats.tsx
@@ -453,7 +453,7 @@ export function AdminStats({ testType, onAddLinkToQuestion }: AdminStatsProps) {
                 Explanations Needing Improvement
               </h4>
               <div className="space-y-2">
-                {questionsWithNegativeFeedback.map((q: any) => (
+                {questionsWithNegativeFeedback.map((q) => (
                   <div 
                     key={q.id} 
                     className="p-3 rounded-lg border border-amber-500/30 bg-amber-500/5 cursor-pointer hover:bg-amber-500/10 transition-colors"

--- a/src/components/admin/BulkImportGlossary.tsx
+++ b/src/components/admin/BulkImportGlossary.tsx
@@ -27,7 +27,7 @@ interface ImportTerm {
 interface ExistingTerm extends ImportTerm {
   id: string;
   created_at?: string;
-  edit_history?: any[];
+  edit_history?: unknown[];
 }
 
 interface ValidationResult {
@@ -101,9 +101,9 @@ export function BulkImportGlossary() {
       const data = JSON.parse(content);
       const terms = Array.isArray(data) ? data : data.terms || data.glossary || [];
       
-      return terms.map((t: any) => ({
-        term: t.term || '',
-        definition: t.definition || '',
+      return terms.map((t: Record<string, unknown>) => ({
+        term: String(t.term || ''),
+        definition: String(t.definition || ''),
       }));
     } catch {
       return [];
@@ -215,8 +215,8 @@ export function BulkImportGlossary() {
           toast.success(`${result.valid.length} terms ready to import`);
         }
       }
-    } catch (error: any) {
-      toast.error('Failed to parse file: ' + error.message);
+    } catch (error: unknown) {
+      toast.error('Failed to parse file: ' + (error instanceof Error ? error.message : String(error)));
     } finally {
       setIsProcessing(false);
       if (fileInputRef.current) fileInputRef.current.value = '';

--- a/src/components/admin/BulkImportQuestions.tsx
+++ b/src/components/admin/BulkImportQuestions.tsx
@@ -26,12 +26,12 @@ interface ImportQuestion {
   subelement: string;
   question_group: string;
   explanation?: string;
-  links?: any[];
+  links?: unknown[];
 }
 
 interface ExistingQuestion extends ImportQuestion {
   created_at?: string;
-  edit_history?: any[];
+  edit_history?: unknown[];
 }
 
 interface ValidationResult {
@@ -134,28 +134,28 @@ export function BulkImportQuestions({ testType }: BulkImportQuestionsProps) {
       // Remove BOM if present
       let cleanContent = content.replace(/^\uFEFF/, '');
       // Fix common invalid escape sequences (like \F, \S, etc.)
-      cleanContent = cleanContent.replace(/\\([^"\\\/bfnrtu])/g, '\\\\$1');
+      cleanContent = cleanContent.replace(/\\([^"\\/bfnrtu])/g, '\\\\$1');
       const data = JSON.parse(cleanContent);
       const questions = Array.isArray(data) ? data : data.questions || [];
       
-      return questions.map((q: any) => ({
-        id: q.id || '',
-        question: q.question || '',
-        options: Array.isArray(q.options) ? q.options : [
-          q.option_a || q.a || '',
-          q.option_b || q.b || '',
-          q.option_c || q.c || '',
-          q.option_d || q.d || '',
+      return questions.map((q: Record<string, unknown>) => ({
+        id: String(q.id || ''),
+        question: String(q.question || ''),
+        options: Array.isArray(q.options) ? q.options.map(String) : [
+          String(q.option_a || q.a || ''),
+          String(q.option_b || q.b || ''),
+          String(q.option_c || q.c || ''),
+          String(q.option_d || q.d || ''),
         ],
-        correct_answer: typeof q.correct_answer === 'number' ? q.correct_answer : 
+        correct_answer: typeof q.correct_answer === 'number' ? q.correct_answer :
           ['a', '0'].includes(String(q.correct_answer).toLowerCase()) ? 0 :
           ['b', '1'].includes(String(q.correct_answer).toLowerCase()) ? 1 :
           ['c', '2'].includes(String(q.correct_answer).toLowerCase()) ? 2 :
           ['d', '3'].includes(String(q.correct_answer).toLowerCase()) ? 3 : 0,
-        subelement: q.subelement || '',
-        question_group: q.question_group || q.group || '',
-        explanation: q.explanation || undefined,
-        links: q.links || undefined,
+        subelement: String(q.subelement || ''),
+        question_group: String(q.question_group || q.group || ''),
+        explanation: q.explanation ? String(q.explanation) : undefined,
+        links: Array.isArray(q.links) ? q.links : undefined,
       }));
     } catch {
       return [];
@@ -229,7 +229,7 @@ export function BulkImportQuestions({ testType }: BulkImportQuestionsProps) {
             subelement: existing.subelement,
             question_group: existing.question_group,
             explanation: existing.explanation || undefined,
-            links: existing.links as any[] || [],
+            links: (existing.links as unknown[]) || [],
           },
           incoming: q,
           resolution: 'keep', // default to keep existing
@@ -288,8 +288,8 @@ export function BulkImportQuestions({ testType }: BulkImportQuestionsProps) {
           toast.success(`${result.valid.length} questions ready to import`);
         }
       }
-    } catch (error: any) {
-      toast.error('Failed to parse file: ' + error.message);
+    } catch (error: unknown) {
+      toast.error('Failed to parse file: ' + (error instanceof Error ? error.message : String(error)));
     } finally {
       setIsProcessing(false);
       if (fileInputRef.current) fileInputRef.current.value = '';

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
   return (

--- a/src/hooks/useProgress.test.ts
+++ b/src/hooks/useProgress.test.ts
@@ -56,13 +56,14 @@ describe('useProgress', () => {
         error: null,
       });
 
-      (supabase.from as any).mockImplementation((table: string) => {
+      vi.mocked(supabase.from).mockImplementation((table: string) => {
         if (table === 'practice_test_results') {
-          return { insert: mockInsert };
+          return { insert: mockInsert } as ReturnType<typeof supabase.from>;
         }
         if (table === 'question_attempts') {
-          return { insert: mockAttemptsInsert };
+          return { insert: mockAttemptsInsert } as ReturnType<typeof supabase.from>;
         }
+        return {} as ReturnType<typeof supabase.from>;
       });
 
       const { result } = renderHook(() => useProgress());
@@ -105,13 +106,14 @@ describe('useProgress', () => {
         }),
       });
 
-      (supabase.from as any).mockImplementation((table: string) => {
+      vi.mocked(supabase.from).mockImplementation((table: string) => {
         if (table === 'practice_test_results') {
-          return { insert: mockInsert };
+          return { insert: mockInsert } as ReturnType<typeof supabase.from>;
         }
         if (table === 'question_attempts') {
-          return { insert: vi.fn().mockResolvedValue({ data: null, error: null }) };
+          return { insert: vi.fn().mockResolvedValue({ data: null, error: null }) } as ReturnType<typeof supabase.from>;
         }
+        return {} as ReturnType<typeof supabase.from>;
       });
 
       const { result } = renderHook(() => useProgress());
@@ -157,13 +159,14 @@ describe('useProgress', () => {
         error: null,
       });
 
-      (supabase.from as any).mockImplementation((table: string) => {
+      vi.mocked(supabase.from).mockImplementation((table: string) => {
         if (table === 'practice_test_results') {
-          return { insert: mockInsert };
+          return { insert: mockInsert } as ReturnType<typeof supabase.from>;
         }
         if (table === 'question_attempts') {
-          return { insert: mockAttemptsInsert };
+          return { insert: mockAttemptsInsert } as ReturnType<typeof supabase.from>;
         }
+        return {} as ReturnType<typeof supabase.from>;
       });
 
       const { result } = renderHook(() => useProgress());
@@ -183,7 +186,7 @@ describe('useProgress', () => {
 
     it('returns null when no user', async () => {
       const { useAuth } = await import('./useAuth');
-      (useAuth as any).mockReturnValue({ user: null });
+      vi.mocked(useAuth).mockReturnValue({ user: null } as ReturnType<typeof useAuth>);
 
       const { result } = renderHook(() => useProgress());
 
@@ -204,7 +207,7 @@ describe('useProgress', () => {
         }),
       });
 
-      (supabase.from as any).mockReturnValue({ insert: mockInsert });
+      vi.mocked(supabase.from).mockReturnValue({ insert: mockInsert } as ReturnType<typeof supabase.from>);
 
       const { result } = renderHook(() => useProgress());
       const testResult = await result.current.saveTestResult([mockQuestion], { 'T1A01': 'A' });
@@ -220,7 +223,7 @@ describe('useProgress', () => {
     beforeEach(async () => {
       // Reset useAuth mock for these tests
       const { useAuth } = await import('./useAuth');
-      vi.mocked(useAuth).mockReturnValue({ user: { id: 'test-user-id' } } as any);
+      vi.mocked(useAuth).mockReturnValue({ user: { id: 'test-user-id' } } as ReturnType<typeof useAuth>);
     });
 
     it('saves random practice attempt', async () => {
@@ -231,7 +234,7 @@ describe('useProgress', () => {
         error: null,
       });
 
-      (supabase.from as any).mockReturnValue({ insert: mockInsert });
+      vi.mocked(supabase.from).mockReturnValue({ insert: mockInsert } as ReturnType<typeof supabase.from>);
 
       const { result } = renderHook(() => useProgress());
 
@@ -254,7 +257,7 @@ describe('useProgress', () => {
         error: null,
       });
 
-      (supabase.from as any).mockReturnValue({ insert: mockInsert });
+      vi.mocked(supabase.from).mockReturnValue({ insert: mockInsert } as ReturnType<typeof supabase.from>);
 
       const { result } = renderHook(() => useProgress());
 
@@ -270,11 +273,11 @@ describe('useProgress', () => {
 
     it('does not save when no user', async () => {
       const { useAuth } = await import('./useAuth');
-      (useAuth as any).mockReturnValue({ user: null });
+      vi.mocked(useAuth).mockReturnValue({ user: null } as ReturnType<typeof useAuth>);
 
       const { supabase } = await import('@/integrations/supabase/client');
       const mockInsert = vi.fn();
-      (supabase.from as any).mockReturnValue({ insert: mockInsert });
+      vi.mocked(supabase.from).mockReturnValue({ insert: mockInsert } as ReturnType<typeof supabase.from>);
 
       const { result } = renderHook(() => useProgress());
 
@@ -291,7 +294,7 @@ describe('useProgress', () => {
         error: null,
       });
 
-      (supabase.from as any).mockReturnValue({ insert: mockInsert });
+      vi.mocked(supabase.from).mockReturnValue({ insert: mockInsert } as ReturnType<typeof supabase.from>);
 
       const { result } = renderHook(() => useProgress());
 

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -7,8 +7,10 @@ describe('cn utility', () => {
   });
 
   it('should handle conditional classes', () => {
-    expect(cn('foo', false && 'bar', 'baz')).toBe('foo baz');
-    expect(cn('foo', true && 'bar', 'baz')).toBe('foo bar baz');
+    const showBar = false;
+    const showBarTrue = true;
+    expect(cn('foo', showBar && 'bar', 'baz')).toBe('foo baz');
+    expect(cn('foo', showBarTrue && 'bar', 'baz')).toBe('foo bar baz');
   });
 
   it('should handle undefined and null values', () => {

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -141,8 +141,8 @@ export default function Auth() {
       if (error) throw error;
       
       setForgotPasswordSent(true);
-    } catch (error: any) {
-      setFormError(error.message || 'Failed to send password reset email');
+    } catch (error: unknown) {
+      setFormError(error instanceof Error ? error.message : 'Failed to send password reset email');
     } finally {
       setIsSubmitting(false);
     }
@@ -161,8 +161,8 @@ export default function Auth() {
       });
       
       if (error) throw error;
-    } catch (error: any) {
-      setFormError(error.message || 'Failed to sign in with Google');
+    } catch (error: unknown) {
+      setFormError(error instanceof Error ? error.message : 'Failed to sign in with Google');
       setIsSubmitting(false);
     }
   };

--- a/src/pages/Dashboard.test.tsx
+++ b/src/pages/Dashboard.test.tsx
@@ -60,18 +60,18 @@ vi.mock('@/hooks/useAppNavigation', () => ({
 // Mock framer-motion
 vi.mock('framer-motion', () => ({
   motion: {
-    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-    p: ({ children, ...props }: any) => <p {...props}>{children}</p>,
-    button: ({ children, onClick, ...props }: any) => (
+    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement> & { children?: React.ReactNode }) => <div {...props}>{children}</div>,
+    p: ({ children, ...props }: React.HTMLAttributes<HTMLParagraphElement> & { children?: React.ReactNode }) => <p {...props}>{children}</p>,
+    button: ({ children, onClick, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement> & { children?: React.ReactNode }) => (
       <button onClick={onClick} {...props}>{children}</button>
     ),
   },
-  AnimatePresence: ({ children }: any) => <>{children}</>,
+  AnimatePresence: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
 }));
 
 // Mock components that render in different views
 vi.mock('@/components/PracticeTest', () => ({
-  PracticeTest: ({ onBack }: any) => (
+  PracticeTest: ({ onBack }: { onBack: () => void }) => (
     <div data-testid="practice-test">
       Practice Test View
       <button onClick={onBack}>Back</button>
@@ -80,7 +80,7 @@ vi.mock('@/components/PracticeTest', () => ({
 }));
 
 vi.mock('@/components/RandomPractice', () => ({
-  RandomPractice: ({ onBack }: any) => (
+  RandomPractice: ({ onBack }: { onBack: () => void }) => (
     <div data-testid="random-practice">
       Random Practice View
       <button onClick={onBack}>Back</button>
@@ -89,7 +89,7 @@ vi.mock('@/components/RandomPractice', () => ({
 }));
 
 vi.mock('@/components/WeakQuestionsReview', () => ({
-  WeakQuestionsReview: ({ onBack }: any) => (
+  WeakQuestionsReview: ({ onBack }: { onBack: () => void }) => (
     <div data-testid="weak-questions">
       Weak Questions View
       <button onClick={onBack}>Back</button>
@@ -98,7 +98,7 @@ vi.mock('@/components/WeakQuestionsReview', () => ({
 }));
 
 vi.mock('@/components/BookmarkedQuestions', () => ({
-  BookmarkedQuestions: ({ onBack }: any) => (
+  BookmarkedQuestions: ({ onBack }: { onBack: () => void }) => (
     <div data-testid="bookmarked-questions">
       Bookmarked Questions View
       <button onClick={onBack}>Back</button>
@@ -107,7 +107,7 @@ vi.mock('@/components/BookmarkedQuestions', () => ({
 }));
 
 vi.mock('@/components/SubelementPractice', () => ({
-  SubelementPractice: ({ onBack }: any) => (
+  SubelementPractice: ({ onBack }: { onBack: () => void }) => (
     <div data-testid="subelement-practice">
       Subelement Practice View
       <button onClick={onBack}>Back</button>
@@ -116,7 +116,7 @@ vi.mock('@/components/SubelementPractice', () => ({
 }));
 
 vi.mock('@/components/Glossary', () => ({
-  Glossary: ({ onStartFlashcards }: any) => (
+  Glossary: ({ onStartFlashcards }: { onStartFlashcards: () => void }) => (
     <div data-testid="glossary">
       Glossary View
       <button onClick={onStartFlashcards}>Start Flashcards</button>
@@ -125,7 +125,7 @@ vi.mock('@/components/Glossary', () => ({
 }));
 
 vi.mock('@/components/GlossaryFlashcards', () => ({
-  GlossaryFlashcards: ({ onBack }: any) => (
+  GlossaryFlashcards: ({ onBack }: { onBack: () => void }) => (
     <div data-testid="glossary-flashcards">
       Glossary Flashcards View
       <button onClick={onBack}>Back</button>
@@ -134,7 +134,7 @@ vi.mock('@/components/GlossaryFlashcards', () => ({
 }));
 
 vi.mock('@/components/TestResultReview', () => ({
-  TestResultReview: ({ onBack }: any) => (
+  TestResultReview: ({ onBack }: { onBack: () => void }) => (
     <div data-testid="test-result-review">
       Test Result Review View
       <button onClick={onBack}>Back</button>
@@ -143,7 +143,7 @@ vi.mock('@/components/TestResultReview', () => ({
 }));
 
 vi.mock('@/components/AppLayout', () => ({
-  AppLayout: ({ children, currentView }: any) => (
+  AppLayout: ({ children, currentView }: { children?: React.ReactNode; currentView: string }) => (
     <div data-testid="app-layout" data-current-view={currentView}>
       {children}
     </div>

--- a/src/test/mocks/supabase.ts
+++ b/src/test/mocks/supabase.ts
@@ -2,7 +2,7 @@ import { vi } from 'vitest';
 
 // Create a chainable mock that returns itself for most methods
 const createChainableMock = () => {
-  const mock: any = {
+  const mock: Record<string, ReturnType<typeof vi.fn>> = {
     select: vi.fn().mockReturnThis(),
     insert: vi.fn().mockReturnThis(),
     update: vi.fn().mockReturnThis(),

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -102,5 +102,8 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require("tailwindcss-animate"),
+  ],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- Replace `any` types with proper TypeScript types in test mocks
- Convert empty interfaces to type aliases in UI components
- Fix catch block error types to use `unknown` with instanceof checks
- Wrap `currentQuestions` in `useMemo` to fix react-hooks/exhaustive-deps warning
- Fix constant binary expression in utils.test.ts
- Fix unnecessary escape character in regex
- Add eslint-disable comment for required `require()` import in tailwind config

## Test plan
- [x] Run `npm run lint` - passes with 0 errors (12 warnings are expected for shadcn/ui components)
- [ ] CI workflow should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)