### PR TITLE
Remove stale unfurl-url function config

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -3,8 +3,5 @@ project_id = "sahfeuvmbnmqusjctrtw"
 [functions.seed-questions]
 verify_jwt = false
 
-[functions.unfurl-url]
-verify_jwt = false
-
 [functions.manage-question-links]
 verify_jwt = false


### PR DESCRIPTION
## Summary
- Removes stale `[functions.unfurl-url]` config entry from `supabase/config.toml`
- This function was never created - the unfurl functionality was consolidated into `manage-question-links`

## Problem
Supabase function deployment was failing with:
```
Error: entrypoint path does not exist (supabase/functions/unfurl-url/index.ts)
```

## Test plan
- [ ] Verify Supabase functions deploy successfully in CI
- [ ] Confirm link preview functionality still works via `manage-question-links`

🤖 Generated with [Claude Code](https://claude.com/claude-code)