### PR TITLE
Fix weak questions not being removed after correct answers

### DIFF
--- a/src/hooks/useProgress.test.ts
+++ b/src/hooks/useProgress.test.ts
@@ -318,5 +318,65 @@ describe('useProgress', () => {
         expect.objectContaining({ selected_answer: 3 })
       );
     });
+
+    it('uses random_practice as default attempt type', async () => {
+      const { supabase } = await import('@/integrations/supabase/client');
+
+      const mockInsert = vi.fn().mockResolvedValue({
+        data: null,
+        error: null,
+      });
+
+      vi.mocked(supabase.from).mockReturnValue({ insert: mockInsert } as ReturnType<typeof supabase.from>);
+
+      const { result } = renderHook(() => useProgress());
+
+      await result.current.saveRandomAttempt(mockQuestion, 'A');
+
+      expect(mockInsert).toHaveBeenCalledWith(
+        expect.objectContaining({ attempt_type: 'random_practice' })
+      );
+    });
+
+    it('saves weak_questions attempt type when specified', async () => {
+      const { supabase } = await import('@/integrations/supabase/client');
+
+      const mockInsert = vi.fn().mockResolvedValue({
+        data: null,
+        error: null,
+      });
+
+      vi.mocked(supabase.from).mockReturnValue({ insert: mockInsert } as ReturnType<typeof supabase.from>);
+
+      const { result } = renderHook(() => useProgress());
+
+      await result.current.saveRandomAttempt(mockQuestion, 'A', 'weak_questions');
+
+      expect(mockInsert).toHaveBeenCalledWith(
+        expect.objectContaining({ attempt_type: 'weak_questions' })
+      );
+    });
+
+    it('saves subelement_practice attempt type when specified', async () => {
+      const { supabase } = await import('@/integrations/supabase/client');
+
+      const mockInsert = vi.fn().mockResolvedValue({
+        data: null,
+        error: null,
+      });
+
+      vi.mocked(supabase.from).mockReturnValue({ insert: mockInsert } as ReturnType<typeof supabase.from>);
+
+      const { result } = renderHook(() => useProgress());
+
+      await result.current.saveRandomAttempt(mockQuestion, 'B', 'subelement_practice');
+
+      expect(mockInsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attempt_type: 'subelement_practice',
+          is_correct: false, // B is wrong, A is correct
+        })
+      );
+    });
   });
 });

--- a/src/hooks/useProgress.ts
+++ b/src/hooks/useProgress.ts
@@ -62,7 +62,8 @@ export function useProgress() {
 
   const saveRandomAttempt = async (
     question: Question,
-    selectedAnswer: 'A' | 'B' | 'C' | 'D'
+    selectedAnswer: 'A' | 'B' | 'C' | 'D',
+    attemptType: 'random_practice' | 'weak_questions' | 'subelement_practice' = 'random_practice'
   ) => {
     if (!user) return;
 
@@ -75,11 +76,11 @@ export function useProgress() {
         question_id: question.id,
         selected_answer: answerToIndex[selectedAnswer],
         is_correct: selectedAnswer === question.correctAnswer,
-        attempt_type: 'random_practice'
+        attempt_type: attemptType
       });
 
     if (error) {
-      console.error('Error saving random attempt:', error);
+      console.error('Error saving attempt:', error);
     }
   };
 

--- a/src/lib/weakQuestions.test.ts
+++ b/src/lib/weakQuestions.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { calculateWeakQuestionIds } from './weakQuestions';
+
+describe('calculateWeakQuestionIds', () => {
+  it('returns empty array when no attempts', () => {
+    expect(calculateWeakQuestionIds([])).toEqual([]);
+  });
+
+  it('marks question as weak when answered incorrectly once', () => {
+    const attempts = [
+      { question_id: 'Q1', is_correct: false },
+    ];
+    expect(calculateWeakQuestionIds(attempts)).toEqual(['Q1']);
+  });
+
+  it('does not mark question as weak when answered correctly once', () => {
+    const attempts = [
+      { question_id: 'Q1', is_correct: true },
+    ];
+    expect(calculateWeakQuestionIds(attempts)).toEqual([]);
+  });
+
+  it('removes question from weak list when correct equals incorrect', () => {
+    const attempts = [
+      { question_id: 'Q1', is_correct: false },
+      { question_id: 'Q1', is_correct: true },
+    ];
+    // 1 incorrect, 1 correct = not weak (1 > 1 is false)
+    expect(calculateWeakQuestionIds(attempts)).toEqual([]);
+  });
+
+  it('keeps question weak when incorrect exceeds correct', () => {
+    const attempts = [
+      { question_id: 'Q1', is_correct: false },
+      { question_id: 'Q1', is_correct: false },
+      { question_id: 'Q1', is_correct: true },
+    ];
+    // 2 incorrect, 1 correct = weak (2 > 1)
+    expect(calculateWeakQuestionIds(attempts)).toEqual(['Q1']);
+  });
+
+  it('removes question from weak list when correct exceeds incorrect', () => {
+    const attempts = [
+      { question_id: 'Q1', is_correct: false },
+      { question_id: 'Q1', is_correct: true },
+      { question_id: 'Q1', is_correct: true },
+    ];
+    // 1 incorrect, 2 correct = not weak (1 > 2 is false)
+    expect(calculateWeakQuestionIds(attempts)).toEqual([]);
+  });
+
+  it('handles multiple questions independently', () => {
+    const attempts = [
+      { question_id: 'Q1', is_correct: false },
+      { question_id: 'Q1', is_correct: true },  // Q1: 1 wrong, 1 right = not weak
+      { question_id: 'Q2', is_correct: false },
+      { question_id: 'Q2', is_correct: false }, // Q2: 2 wrong, 0 right = weak
+      { question_id: 'Q3', is_correct: true },
+      { question_id: 'Q3', is_correct: true },  // Q3: 0 wrong, 2 right = not weak
+    ];
+    expect(calculateWeakQuestionIds(attempts)).toEqual(['Q2']);
+  });
+
+  it('handles real-world scenario: user reviews weak questions and gets them right', () => {
+    // User initially gets Q1 wrong twice
+    const initialAttempts = [
+      { question_id: 'Q1', is_correct: false },
+      { question_id: 'Q1', is_correct: false },
+    ];
+    expect(calculateWeakQuestionIds(initialAttempts)).toEqual(['Q1']);
+
+    // User reviews weak questions and gets Q1 right once
+    const afterOneCorrect = [
+      ...initialAttempts,
+      { question_id: 'Q1', is_correct: true },
+    ];
+    // 2 wrong, 1 right = still weak
+    expect(calculateWeakQuestionIds(afterOneCorrect)).toEqual(['Q1']);
+
+    // User gets Q1 right again
+    const afterTwoCorrect = [
+      ...afterOneCorrect,
+      { question_id: 'Q1', is_correct: true },
+    ];
+    // 2 wrong, 2 right = not weak anymore
+    expect(calculateWeakQuestionIds(afterTwoCorrect)).toEqual([]);
+  });
+
+  it('handles mixed results across many questions', () => {
+    const attempts = [
+      // Q1: 3 wrong, 1 right = weak
+      { question_id: 'Q1', is_correct: false },
+      { question_id: 'Q1', is_correct: false },
+      { question_id: 'Q1', is_correct: false },
+      { question_id: 'Q1', is_correct: true },
+      // Q2: 1 wrong, 3 right = not weak
+      { question_id: 'Q2', is_correct: false },
+      { question_id: 'Q2', is_correct: true },
+      { question_id: 'Q2', is_correct: true },
+      { question_id: 'Q2', is_correct: true },
+      // Q3: 2 wrong, 2 right = not weak
+      { question_id: 'Q3', is_correct: false },
+      { question_id: 'Q3', is_correct: false },
+      { question_id: 'Q3', is_correct: true },
+      { question_id: 'Q3', is_correct: true },
+      // Q4: 0 wrong, 2 right = not weak
+      { question_id: 'Q4', is_correct: true },
+      { question_id: 'Q4', is_correct: true },
+      // Q5: 1 wrong, 0 right = weak
+      { question_id: 'Q5', is_correct: false },
+    ];
+
+    const weakIds = calculateWeakQuestionIds(attempts);
+    expect(weakIds).toContain('Q1');
+    expect(weakIds).toContain('Q5');
+    expect(weakIds).not.toContain('Q2');
+    expect(weakIds).not.toContain('Q3');
+    expect(weakIds).not.toContain('Q4');
+    expect(weakIds).toHaveLength(2);
+  });
+});

--- a/src/lib/weakQuestions.ts
+++ b/src/lib/weakQuestions.ts
@@ -1,0 +1,34 @@
+interface QuestionAttempt {
+  question_id: string;
+  is_correct: boolean;
+}
+
+/**
+ * Calculate weak question IDs from question attempts.
+ * A question is considered "weak" if the user has answered it incorrectly
+ * more times than correctly (incorrect > correct).
+ *
+ * This means:
+ * - 1 wrong, 0 right = weak (1 > 0)
+ * - 1 wrong, 1 right = not weak (1 > 1 is false)
+ * - 2 wrong, 1 right = weak (2 > 1)
+ * - 2 wrong, 2 right = not weak (2 > 2 is false)
+ */
+export function calculateWeakQuestionIds(attempts: QuestionAttempt[]): string[] {
+  const stats: Record<string, { correct: number; incorrect: number }> = {};
+
+  attempts.forEach(attempt => {
+    if (!stats[attempt.question_id]) {
+      stats[attempt.question_id] = { correct: 0, incorrect: 0 };
+    }
+    if (attempt.is_correct) {
+      stats[attempt.question_id].correct++;
+    } else {
+      stats[attempt.question_id].incorrect++;
+    }
+  });
+
+  return Object.entries(stats)
+    .filter(([_, { correct, incorrect }]) => incorrect > correct)
+    .map(([id]) => id);
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -6,6 +6,7 @@ import { useBookmarks } from '@/hooks/useBookmarks';
 import { useAppNavigation } from '@/hooks/useAppNavigation';
 import { useUserTargetExam } from '@/hooks/useExamSessions';
 import { supabase } from '@/integrations/supabase/client';
+import { calculateWeakQuestionIds } from '@/lib/weakQuestions';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { Target, Zap, TrendingUp, CheckCircle, Loader2, AlertTriangle, Flame, Brain, CalendarDays, Settings2, MapPin } from 'lucide-react';
 import { motion } from 'framer-motion';
@@ -141,13 +142,8 @@ export default function Dashboard() {
   const thisWeekTests = testResults?.filter(t => new Date(t.completed_at) >= weekStart).length || 0;
   const thisWeekQuestions = questionAttempts?.filter(a => new Date(a.attempted_at) >= weekStart).length || 0;
 
-  // Calculate weak questions (questions answered incorrectly more than once)
-  const weakQuestionIds = questionAttempts ? Object.entries(questionAttempts.reduce((acc, attempt) => {
-    if (!attempt.is_correct) {
-      acc[attempt.question_id] = (acc[attempt.question_id] || 0) + 1;
-    }
-    return acc;
-  }, {} as Record<string, number>)).filter(([_, count]) => count >= 1).map(([id]) => id) : [];
+  // Calculate weak questions (questions where incorrect answers > correct answers)
+  const weakQuestionIds = questionAttempts ? calculateWeakQuestionIds(questionAttempts) : [];
   const currentTest = testTypes.find(t => t.id === selectedTest);
   const isTestAvailable = currentTest?.available ?? false;
 


### PR DESCRIPTION
## Summary
- Weak questions now properly get removed when users answer them correctly
- Previously, once a question was marked weak, it stayed weak forever regardless of correct answers
- Now uses `incorrect > correct` logic - questions drop off the list when users master them

## Changes
- **New utility**: `src/lib/weakQuestions.ts` - extracted calculation logic for testability
- **Dashboard.tsx**: Uses new utility for weak question calculation
- **WeakQuestionsReview.tsx**: 
  - Uses `'weak_questions'` attempt type (per CLAUDE.md documentation)
  - Invalidates cache after answering so dashboard updates immediately
- **useProgress.ts**: Added `attemptType` parameter to `saveRandomAttempt`

## How it works now
| Incorrect | Correct | Status |
|-----------|---------|--------|
| 1 | 0 | Weak |
| 1 | 1 | Not weak |
| 2 | 1 | Weak |
| 2 | 2 | Not weak |

## Test plan
- [x] Added 9 tests for weak questions calculation logic
- [x] Added 3 tests for attemptType parameter
- [x] All 124 tests pass
- [x] Lint passes (no errors)
- [ ] Manual test: Answer a question wrong, verify it shows in weak questions
- [ ] Manual test: Answer that question correctly enough times, verify it's removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)