### PR TITLE
Fix bookmarks empty state 'Start Practicing' button

### DIFF
--- a/src/components/BookmarkedQuestions.tsx
+++ b/src/components/BookmarkedQuestions.tsx
@@ -11,9 +11,11 @@ import { motion } from "framer-motion";
 
 interface BookmarkedQuestionsProps {
   onBack: () => void;
+  onStartPractice: () => void;
 }
 export function BookmarkedQuestions({
-  onBack
+  onBack,
+  onStartPractice
 }: BookmarkedQuestionsProps) {
   const {
     data: allQuestions,
@@ -130,7 +132,7 @@ export function BookmarkedQuestions({
             <p className="text-muted-foreground mb-4">
               Bookmark questions during practice to review them later
             </p>
-            <Button onClick={onBack}>Start Practicing</Button>
+            <Button onClick={onStartPractice}>Start Practicing</Button>
           </motion.div> : <motion.div initial={{
         opacity: 0,
         y: 20


### PR DESCRIPTION
## Summary

The "Start Practicing" button on the bookmarks empty state had two issues:
1. Clicking it had no visible effect (navigation wasn't working)
2. It was supposed to go to random practice, but was going to dashboard

## Root Cause

**Issue 1:** When the URL contained `?view=bookmarks`, calling `setCurrentView('dashboard')` triggered a `useEffect` that read the URL param and immediately set the view back to `'bookmarks'`.

**Issue 2:** The button called `onBack` which navigated to dashboard, but "Start Practicing" should go to random practice.

## Fix

1. Add `onStartPractice` prop to BookmarkedQuestions component
2. "Start Practicing" button now calls `onStartPractice` → navigates to random-practice
3. Only read URL params on initial mount (empty dependency array)
4. Create `changeView()` helper that updates both React state and URL params

## Test plan

- [ ] Go to Bookmarks with no bookmarks saved
- [ ] Click "Start Practicing" button
- [ ] Verify it navigates to Random Practice (not dashboard)
- [ ] Verify URL updates to `?view=random-practice`

🤖 Generated with [Claude Code](https://claude.com/claude-code)