### PR TITLE
Fix bulk import JSON parser for LaTeX content

### DIFF
--- a/src/components/admin/BulkImportQuestions.tsx
+++ b/src/components/admin/BulkImportQuestions.tsx
@@ -17,37 +17,19 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { ConflictResolutionDialog, ConflictItem, ResolutionAction } from "./ConflictResolutionDialog";
-
-interface ImportQuestion {
-  id: string;
-  question: string;
-  options: string[];
-  correct_answer: number;
-  subelement: string;
-  question_group: string;
-  explanation?: string;
-  links?: unknown[];
-}
-
-interface ExistingQuestion extends ImportQuestion {
-  created_at?: string;
-  edit_history?: unknown[];
-}
-
-interface ValidationResult {
-  valid: ImportQuestion[];
-  errors: { row: number; id?: string; errors: string[] }[];
-}
+import {
+  ImportQuestion,
+  ValidationResult,
+  TestType,
+  TEST_TYPE_PREFIXES,
+  parseCSV,
+  parseJSON,
+  validateQuestions,
+} from "@/lib/questionImportParser";
 
 interface BulkImportQuestionsProps {
-  testType: 'technician' | 'general' | 'extra';
+  testType: TestType;
 }
-
-const TEST_TYPE_PREFIXES = {
-  technician: 'T',
-  general: 'G',
-  extra: 'E',
-};
 
 type ImportStep = 'upload' | 'conflicts' | 'importing';
 
@@ -66,139 +48,6 @@ export function BulkImportQuestions({ testType }: BulkImportQuestionsProps) {
   const [newQuestions, setNewQuestions] = useState<ImportQuestion[]>([]);
 
   const prefix = TEST_TYPE_PREFIXES[testType];
-
-  const parseCSV = (content: string): ImportQuestion[] => {
-    const lines = content.trim().split('\n');
-    if (lines.length < 2) return [];
-
-    const headers = lines[0].toLowerCase().split(',').map(h => h.trim().replace(/"/g, ''));
-    const questions: ImportQuestion[] = [];
-
-    for (let i = 1; i < lines.length; i++) {
-      const values = parseCSVLine(lines[i]);
-      if (values.length < 9) continue;
-
-      const getCol = (name: string) => {
-        const idx = headers.indexOf(name);
-        return idx >= 0 ? values[idx]?.trim().replace(/^"|"$/g, '') : '';
-      };
-
-      const correctAnswerRaw = getCol('correct_answer') || getCol('correct');
-      let correctAnswer = 0;
-      if (['a', '0'].includes(correctAnswerRaw.toLowerCase())) correctAnswer = 0;
-      else if (['b', '1'].includes(correctAnswerRaw.toLowerCase())) correctAnswer = 1;
-      else if (['c', '2'].includes(correctAnswerRaw.toLowerCase())) correctAnswer = 2;
-      else if (['d', '3'].includes(correctAnswerRaw.toLowerCase())) correctAnswer = 3;
-
-      questions.push({
-        id: getCol('id'),
-        question: getCol('question'),
-        options: [
-          getCol('option_a') || getCol('a'),
-          getCol('option_b') || getCol('b'),
-          getCol('option_c') || getCol('c'),
-          getCol('option_d') || getCol('d'),
-        ],
-        correct_answer: correctAnswer,
-        subelement: getCol('subelement'),
-        question_group: getCol('question_group') || getCol('group'),
-        explanation: getCol('explanation') || undefined,
-      });
-    }
-
-    return questions;
-  };
-
-  const parseCSVLine = (line: string): string[] => {
-    const result: string[] = [];
-    let current = '';
-    let inQuotes = false;
-
-    for (let i = 0; i < line.length; i++) {
-      const char = line[i];
-      if (char === '"') {
-        inQuotes = !inQuotes;
-      } else if (char === ',' && !inQuotes) {
-        result.push(current);
-        current = '';
-      } else {
-        current += char;
-      }
-    }
-    result.push(current);
-    return result;
-  };
-
-  const parseJSON = (content: string): ImportQuestion[] => {
-    try {
-      // Remove BOM if present
-      let cleanContent = content.replace(/^\uFEFF/, '');
-      // Fix common invalid escape sequences (like \F, \S, etc.)
-      cleanContent = cleanContent.replace(/\\([^"\\/bfnrtu])/g, '\\\\$1');
-      const data = JSON.parse(cleanContent);
-      const questions = Array.isArray(data) ? data : data.questions || [];
-      
-      return questions.map((q: Record<string, unknown>) => ({
-        id: String(q.id || ''),
-        question: String(q.question || ''),
-        options: Array.isArray(q.options) ? q.options.map(String) : [
-          String(q.option_a || q.a || ''),
-          String(q.option_b || q.b || ''),
-          String(q.option_c || q.c || ''),
-          String(q.option_d || q.d || ''),
-        ],
-        correct_answer: typeof q.correct_answer === 'number' ? q.correct_answer :
-          ['a', '0'].includes(String(q.correct_answer).toLowerCase()) ? 0 :
-          ['b', '1'].includes(String(q.correct_answer).toLowerCase()) ? 1 :
-          ['c', '2'].includes(String(q.correct_answer).toLowerCase()) ? 2 :
-          ['d', '3'].includes(String(q.correct_answer).toLowerCase()) ? 3 : 0,
-        subelement: String(q.subelement || ''),
-        question_group: String(q.question_group || q.group || ''),
-        explanation: q.explanation ? String(q.explanation) : undefined,
-        links: Array.isArray(q.links) ? q.links : undefined,
-      }));
-    } catch {
-      return [];
-    }
-  };
-
-  const validateQuestions = (questions: ImportQuestion[]): ValidationResult => {
-    const valid: ImportQuestion[] = [];
-    const errors: { row: number; id?: string; errors: string[] }[] = [];
-
-    questions.forEach((q, index) => {
-      const rowErrors: string[] = [];
-
-      if (!q.id) rowErrors.push('Missing ID');
-      else if (!q.id.toUpperCase().startsWith(prefix)) {
-        rowErrors.push(`ID must start with "${prefix}" for ${testType} questions`);
-      }
-
-      if (!q.question) rowErrors.push('Missing question text');
-      if (!q.options || q.options.length !== 4) rowErrors.push('Must have exactly 4 options');
-      else if (q.options.some(o => !o?.trim())) rowErrors.push('All options must have text');
-
-      if (q.correct_answer < 0 || q.correct_answer > 3) rowErrors.push('Invalid correct answer');
-      if (!q.subelement) rowErrors.push('Missing subelement');
-      if (!q.question_group) rowErrors.push('Missing question group');
-
-      if (rowErrors.length > 0) {
-        errors.push({ row: index + 2, id: q.id, errors: rowErrors });
-      } else {
-        valid.push({
-          ...q,
-          id: q.id.toUpperCase().trim(),
-          question: q.question.trim(),
-          options: q.options.map(o => o.trim()),
-          subelement: q.subelement.trim(),
-          question_group: q.question_group.trim(),
-          explanation: q.explanation?.trim(),
-        });
-      }
-    });
-
-    return { valid, errors };
-  };
 
   const checkForConflicts = async (questions: ImportQuestion[]) => {
     const ids = questions.map(q => q.id);
@@ -269,7 +118,7 @@ export function BulkImportQuestions({ testType }: BulkImportQuestionsProps) {
         return;
       }
 
-      const result = validateQuestions(questions);
+      const result = validateQuestions(questions, testType);
       setValidationResult(result);
 
       if (result.valid.length === 0) {

--- a/src/lib/questionImportParser.test.ts
+++ b/src/lib/questionImportParser.test.ts
@@ -1,0 +1,449 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseCSVLine,
+  parseCSV,
+  parseJSON,
+  validateQuestions,
+  ImportQuestion,
+  TEST_TYPE_PREFIXES,
+} from './questionImportParser';
+
+describe('parseCSVLine', () => {
+  it('parses simple comma-separated values', () => {
+    expect(parseCSVLine('a,b,c,d')).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('handles quoted fields with commas inside', () => {
+    expect(parseCSVLine('a,"b,c",d')).toEqual(['a', 'b,c', 'd']);
+  });
+
+  it('handles empty fields', () => {
+    expect(parseCSVLine('a,,c,')).toEqual(['a', '', 'c', '']);
+  });
+
+  it('handles quoted empty fields', () => {
+    expect(parseCSVLine('a,"",c')).toEqual(['a', '', 'c']);
+  });
+
+  it('handles fields with quotes inside (strips quotes)', () => {
+    // Note: The parser strips double-quotes rather than unescaping them
+    // This is acceptable for the question import use case
+    expect(parseCSVLine('"hello ""world""",b')).toEqual(['hello world', 'b']);
+  });
+});
+
+describe('parseCSV', () => {
+  it('returns empty array for content with only headers', () => {
+    const csv = 'id,question,option_a,option_b,option_c,option_d,correct_answer,subelement,question_group';
+    expect(parseCSV(csv)).toEqual([]);
+  });
+
+  it('returns empty array for empty content', () => {
+    expect(parseCSV('')).toEqual([]);
+  });
+
+  it('parses valid CSV with standard column names', () => {
+    const csv = `id,question,option_a,option_b,option_c,option_d,correct_answer,subelement,question_group,explanation
+T1A01,"Test question?","Option A","Option B","Option C","Option D",B,T1,T1A,"Test explanation"`;
+
+    const result = parseCSV(csv);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      id: 'T1A01',
+      question: 'Test question?',
+      options: ['Option A', 'Option B', 'Option C', 'Option D'],
+      correct_answer: 1,
+      subelement: 'T1',
+      question_group: 'T1A',
+      explanation: 'Test explanation',
+    });
+  });
+
+  it('parses correct_answer as numeric values (0-3)', () => {
+    const csv = `id,question,option_a,option_b,option_c,option_d,correct_answer,subelement,question_group
+T1A01,"Q1","A","B","C","D",0,T1,T1A
+T1A02,"Q2","A","B","C","D",1,T1,T1A
+T1A03,"Q3","A","B","C","D",2,T1,T1A
+T1A04,"Q4","A","B","C","D",3,T1,T1A`;
+
+    const result = parseCSV(csv);
+    expect(result[0].correct_answer).toBe(0);
+    expect(result[1].correct_answer).toBe(1);
+    expect(result[2].correct_answer).toBe(2);
+    expect(result[3].correct_answer).toBe(3);
+  });
+
+  it('parses correct_answer as letter values (A-D)', () => {
+    const csv = `id,question,option_a,option_b,option_c,option_d,correct_answer,subelement,question_group
+T1A01,"Q1","A","B","C","D",A,T1,T1A
+T1A02,"Q2","A","B","C","D",B,T1,T1A
+T1A03,"Q3","A","B","C","D",C,T1,T1A
+T1A04,"Q4","A","B","C","D",D,T1,T1A`;
+
+    const result = parseCSV(csv);
+    expect(result[0].correct_answer).toBe(0);
+    expect(result[1].correct_answer).toBe(1);
+    expect(result[2].correct_answer).toBe(2);
+    expect(result[3].correct_answer).toBe(3);
+  });
+
+  it('supports alternate column names (a, b, c, d, group, correct)', () => {
+    const csv = `id,question,a,b,c,d,correct,subelement,group
+T1A01,"Test?","Opt A","Opt B","Opt C","Opt D",C,T1,T1A`;
+
+    const result = parseCSV(csv);
+    expect(result[0].options).toEqual(['Opt A', 'Opt B', 'Opt C', 'Opt D']);
+    expect(result[0].correct_answer).toBe(2);
+    expect(result[0].question_group).toBe('T1A');
+  });
+
+  it('skips rows with insufficient columns', () => {
+    const csv = `id,question,option_a,option_b,option_c,option_d,correct_answer,subelement,question_group
+T1A01,"Q1","A","B","C","D",0,T1,T1A
+incomplete,row,only,four`;
+
+    const result = parseCSV(csv);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('T1A01');
+  });
+
+  it('handles questions with commas in text', () => {
+    const csv = `id,question,option_a,option_b,option_c,option_d,correct_answer,subelement,question_group
+T1A01,"What is 1, 2, and 3?","A, first","B, second","C, third","D, fourth",A,T1,T1A`;
+
+    const result = parseCSV(csv);
+    expect(result[0].question).toBe('What is 1, 2, and 3?');
+    expect(result[0].options[0]).toBe('A, first');
+  });
+});
+
+describe('parseJSON', () => {
+  it('parses valid JSON array', () => {
+    const json = JSON.stringify([
+      {
+        id: 'G1A01',
+        question: 'Test question?',
+        options: ['A', 'B', 'C', 'D'],
+        correct_answer: 2,
+        subelement: 'G1',
+        question_group: 'G1A',
+        explanation: 'Test explanation',
+      },
+    ]);
+
+    const result = parseJSON(json);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('G1A01');
+    expect(result[0].correct_answer).toBe(2);
+    expect(result[0].explanation).toBe('Test explanation');
+  });
+
+  it('parses JSON with questions property', () => {
+    const json = JSON.stringify({
+      questions: [
+        {
+          id: 'E1A01',
+          question: 'Test?',
+          options: ['A', 'B', 'C', 'D'],
+          correct_answer: 0,
+          subelement: 'E1',
+          question_group: 'E1A',
+        },
+      ],
+    });
+
+    const result = parseJSON(json);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('E1A01');
+  });
+
+  it('handles BOM (Byte Order Mark) at start of file', () => {
+    const jsonWithBom = '\uFEFF' + JSON.stringify([
+      {
+        id: 'T1A01',
+        question: 'Test?',
+        options: ['A', 'B', 'C', 'D'],
+        correct_answer: 1,
+        subelement: 'T1',
+        question_group: 'T1A',
+      },
+    ]);
+
+    const result = parseJSON(jsonWithBom);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('T1A01');
+  });
+
+  it('returns empty array for invalid JSON', () => {
+    expect(parseJSON('not valid json')).toEqual([]);
+    expect(parseJSON('{')).toEqual([]);
+    expect(parseJSON('')).toEqual([]);
+  });
+
+  it('handles correct_answer as string letter', () => {
+    const json = JSON.stringify([
+      { id: 'T1A01', question: 'Q?', options: ['A', 'B', 'C', 'D'], correct_answer: 'A', subelement: 'T1', question_group: 'T1A' },
+      { id: 'T1A02', question: 'Q?', options: ['A', 'B', 'C', 'D'], correct_answer: 'B', subelement: 'T1', question_group: 'T1A' },
+      { id: 'T1A03', question: 'Q?', options: ['A', 'B', 'C', 'D'], correct_answer: 'C', subelement: 'T1', question_group: 'T1A' },
+      { id: 'T1A04', question: 'Q?', options: ['A', 'B', 'C', 'D'], correct_answer: 'D', subelement: 'T1', question_group: 'T1A' },
+    ]);
+
+    const result = parseJSON(json);
+    expect(result[0].correct_answer).toBe(0);
+    expect(result[1].correct_answer).toBe(1);
+    expect(result[2].correct_answer).toBe(2);
+    expect(result[3].correct_answer).toBe(3);
+  });
+
+  it('handles correct_answer as string number', () => {
+    const json = JSON.stringify([
+      { id: 'T1A01', question: 'Q?', options: ['A', 'B', 'C', 'D'], correct_answer: '0', subelement: 'T1', question_group: 'T1A' },
+      { id: 'T1A02', question: 'Q?', options: ['A', 'B', 'C', 'D'], correct_answer: '3', subelement: 'T1', question_group: 'T1A' },
+    ]);
+
+    const result = parseJSON(json);
+    expect(result[0].correct_answer).toBe(0);
+    expect(result[1].correct_answer).toBe(3);
+  });
+
+  it('supports alternate property names (option_a, group)', () => {
+    const json = JSON.stringify([
+      {
+        id: 'T1A01',
+        question: 'Test?',
+        option_a: 'A',
+        option_b: 'B',
+        option_c: 'C',
+        option_d: 'D',
+        correct_answer: 1,
+        subelement: 'T1',
+        group: 'T1A',
+      },
+    ]);
+
+    const result = parseJSON(json);
+    expect(result[0].options).toEqual(['A', 'B', 'C', 'D']);
+    expect(result[0].question_group).toBe('T1A');
+  });
+
+  it('preserves links array if present', () => {
+    const json = JSON.stringify([
+      {
+        id: 'T1A01',
+        question: 'Test?',
+        options: ['A', 'B', 'C', 'D'],
+        correct_answer: 0,
+        subelement: 'T1',
+        question_group: 'T1A',
+        links: [{ url: 'https://example.com', title: 'Example' }],
+      },
+    ]);
+
+    const result = parseJSON(json);
+    expect(result[0].links).toEqual([{ url: 'https://example.com', title: 'Example' }]);
+  });
+
+  it('handles JSON with LaTeX-style math notation (escaped backslashes)', () => {
+    // This test ensures the parser correctly handles LaTeX expressions like $\\S 97.301$
+    const json = JSON.stringify([
+      {
+        id: 'G1A01',
+        question: 'On which bands are there portions where General class licensees cannot transmit?',
+        options: ['60 meters', '160 meters', '80 meters', '80 meters, 20 meters'],
+        correct_answer: 2,
+        subelement: 'G1',
+        question_group: 'G1A',
+        explanation: 'FCC Rule $\\S 97.301(\\text{d})$ outlines the General class frequency privileges.',
+      },
+    ]);
+
+    const result = parseJSON(json);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('G1A01');
+    expect(result[0].explanation).toContain('$\\S 97.301(\\text{d})$');
+  });
+
+  it('handles complex LaTeX expressions with multiple escape sequences', () => {
+    const json = JSON.stringify([
+      {
+        id: 'G1C01',
+        question: 'What is the maximum power?',
+        options: ['200 watts', '1000 watts', '1500 watts', '2000 watts'],
+        correct_answer: 0,
+        subelement: 'G1',
+        question_group: 'G1C',
+        explanation: 'The $30\\text{-meter}$ band ($10.100 \\text{MHz}$ to $10.150 \\text{MHz}$) limit is $200$ watts.',
+      },
+    ]);
+
+    const result = parseJSON(json);
+    expect(result).toHaveLength(1);
+    expect(result[0].explanation).toContain('$30\\text{-meter}$');
+    expect(result[0].explanation).toContain('$10.100 \\text{MHz}$');
+  });
+
+  it('handles missing optional fields gracefully', () => {
+    const json = JSON.stringify([
+      {
+        id: 'T1A01',
+        question: 'Test?',
+        options: ['A', 'B', 'C', 'D'],
+        correct_answer: 0,
+        subelement: 'T1',
+        question_group: 'T1A',
+        // no explanation or links
+      },
+    ]);
+
+    const result = parseJSON(json);
+    expect(result[0].explanation).toBeUndefined();
+    expect(result[0].links).toBeUndefined();
+  });
+});
+
+describe('validateQuestions', () => {
+  const validQuestion: ImportQuestion = {
+    id: 'T1A01',
+    question: 'What is the test question?',
+    options: ['Option A', 'Option B', 'Option C', 'Option D'],
+    correct_answer: 1,
+    subelement: 'T1',
+    question_group: 'T1A',
+  };
+
+  it('accepts valid technician questions', () => {
+    const result = validateQuestions([validQuestion], 'technician');
+    expect(result.valid).toHaveLength(1);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('accepts valid general questions', () => {
+    const generalQuestion = { ...validQuestion, id: 'G1A01', subelement: 'G1', question_group: 'G1A' };
+    const result = validateQuestions([generalQuestion], 'general');
+    expect(result.valid).toHaveLength(1);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('accepts valid extra questions', () => {
+    const extraQuestion = { ...validQuestion, id: 'E1A01', subelement: 'E1', question_group: 'E1A' };
+    const result = validateQuestions([extraQuestion], 'extra');
+    expect(result.valid).toHaveLength(1);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('rejects questions with wrong prefix', () => {
+    const result = validateQuestions([validQuestion], 'general');
+    expect(result.valid).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].errors).toContain('ID must start with "G" for general questions');
+  });
+
+  it('rejects questions with missing ID', () => {
+    const noId = { ...validQuestion, id: '' };
+    const result = validateQuestions([noId], 'technician');
+    expect(result.errors[0].errors).toContain('Missing ID');
+  });
+
+  it('rejects questions with missing question text', () => {
+    const noQuestion = { ...validQuestion, question: '' };
+    const result = validateQuestions([noQuestion], 'technician');
+    expect(result.errors[0].errors).toContain('Missing question text');
+  });
+
+  it('rejects questions with missing options', () => {
+    const noOptions = { ...validQuestion, options: [] as string[] };
+    const result = validateQuestions([noOptions], 'technician');
+    expect(result.errors[0].errors).toContain('Must have exactly 4 options');
+  });
+
+  it('rejects questions with empty option text', () => {
+    const emptyOption = { ...validQuestion, options: ['A', '', 'C', 'D'] };
+    const result = validateQuestions([emptyOption], 'technician');
+    expect(result.errors[0].errors).toContain('All options must have text');
+  });
+
+  it('rejects questions with invalid correct_answer', () => {
+    const invalidAnswer = { ...validQuestion, correct_answer: 5 };
+    const result = validateQuestions([invalidAnswer], 'technician');
+    expect(result.errors[0].errors).toContain('Invalid correct answer');
+  });
+
+  it('rejects questions with missing subelement', () => {
+    const noSubelement = { ...validQuestion, subelement: '' };
+    const result = validateQuestions([noSubelement], 'technician');
+    expect(result.errors[0].errors).toContain('Missing subelement');
+  });
+
+  it('rejects questions with missing question_group', () => {
+    const noGroup = { ...validQuestion, question_group: '' };
+    const result = validateQuestions([noGroup], 'technician');
+    expect(result.errors[0].errors).toContain('Missing question group');
+  });
+
+  it('normalizes valid questions (uppercase ID, trimmed strings)', () => {
+    // Note: ID prefix check is case-insensitive but happens before trimming
+    // So IDs should not have leading/trailing spaces (they would fail validation)
+    const messyQuestion = {
+      ...validQuestion,
+      id: 't1a01',
+      question: '  Test question?  ',
+      options: [' A ', ' B ', ' C ', ' D '],
+      subelement: ' T1 ',
+      question_group: ' T1A ',
+      explanation: '  Some explanation  ',
+    };
+
+    const result = validateQuestions([messyQuestion], 'technician');
+    expect(result.valid[0].id).toBe('T1A01');
+    expect(result.valid[0].question).toBe('Test question?');
+    expect(result.valid[0].options).toEqual(['A', 'B', 'C', 'D']);
+    expect(result.valid[0].subelement).toBe('T1');
+    expect(result.valid[0].question_group).toBe('T1A');
+    expect(result.valid[0].explanation).toBe('Some explanation');
+  });
+
+  it('reports correct row numbers for errors (1-indexed, accounting for header)', () => {
+    const questions = [
+      validQuestion,
+      { ...validQuestion, id: '' }, // Row 3 (index 1 + header row 1 + 1)
+      validQuestion,
+    ];
+
+    const result = validateQuestions(questions, 'technician');
+    expect(result.errors[0].row).toBe(3); // 1 (header) + 1 (first row) + 1 (0-indexed)
+  });
+
+  it('handles multiple questions with mixed validity', () => {
+    const questions = [
+      validQuestion,
+      { ...validQuestion, id: 'G1A01' }, // Wrong prefix
+      { ...validQuestion, id: 'T1A02' },
+      { ...validQuestion, question: '' }, // Missing question
+    ];
+
+    const result = validateQuestions(questions, 'technician');
+    expect(result.valid).toHaveLength(2);
+    expect(result.errors).toHaveLength(2);
+  });
+
+  it('handles case-insensitive ID prefix matching', () => {
+    const lowercaseId = { ...validQuestion, id: 't1a01' };
+    const result = validateQuestions([lowercaseId], 'technician');
+    expect(result.valid).toHaveLength(1);
+    expect(result.valid[0].id).toBe('T1A01'); // Normalized to uppercase
+  });
+});
+
+describe('TEST_TYPE_PREFIXES', () => {
+  it('has correct prefix for technician', () => {
+    expect(TEST_TYPE_PREFIXES.technician).toBe('T');
+  });
+
+  it('has correct prefix for general', () => {
+    expect(TEST_TYPE_PREFIXES.general).toBe('G');
+  });
+
+  it('has correct prefix for extra', () => {
+    expect(TEST_TYPE_PREFIXES.extra).toBe('E');
+  });
+});

--- a/src/lib/questionImportParser.ts
+++ b/src/lib/questionImportParser.ts
@@ -1,0 +1,178 @@
+/**
+ * Utility functions for parsing and validating question import files.
+ * Supports CSV and JSON formats for bulk importing questions.
+ */
+
+export interface ImportQuestion {
+  id: string;
+  question: string;
+  options: string[];
+  correct_answer: number;
+  subelement: string;
+  question_group: string;
+  explanation?: string;
+  links?: unknown[];
+}
+
+export interface ValidationResult {
+  valid: ImportQuestion[];
+  errors: { row: number; id?: string; errors: string[] }[];
+}
+
+export type TestType = 'technician' | 'general' | 'extra';
+
+export const TEST_TYPE_PREFIXES: Record<TestType, string> = {
+  technician: 'T',
+  general: 'G',
+  extra: 'E',
+};
+
+/**
+ * Parse a single CSV line, handling quoted fields with commas inside.
+ */
+export function parseCSVLine(line: string): string[] {
+  const result: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (char === '"') {
+      inQuotes = !inQuotes;
+    } else if (char === ',' && !inQuotes) {
+      result.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+  result.push(current);
+  return result;
+}
+
+/**
+ * Parse CSV content into an array of ImportQuestion objects.
+ */
+export function parseCSV(content: string): ImportQuestion[] {
+  const lines = content.trim().split('\n');
+  if (lines.length < 2) return [];
+
+  const headers = lines[0].toLowerCase().split(',').map(h => h.trim().replace(/"/g, ''));
+  const questions: ImportQuestion[] = [];
+
+  for (let i = 1; i < lines.length; i++) {
+    const values = parseCSVLine(lines[i]);
+    if (values.length < 9) continue;
+
+    const getCol = (name: string) => {
+      const idx = headers.indexOf(name);
+      return idx >= 0 ? values[idx]?.trim().replace(/^"|"$/g, '') : '';
+    };
+
+    const correctAnswerRaw = getCol('correct_answer') || getCol('correct');
+    let correctAnswer = 0;
+    if (['a', '0'].includes(correctAnswerRaw.toLowerCase())) correctAnswer = 0;
+    else if (['b', '1'].includes(correctAnswerRaw.toLowerCase())) correctAnswer = 1;
+    else if (['c', '2'].includes(correctAnswerRaw.toLowerCase())) correctAnswer = 2;
+    else if (['d', '3'].includes(correctAnswerRaw.toLowerCase())) correctAnswer = 3;
+
+    questions.push({
+      id: getCol('id'),
+      question: getCol('question'),
+      options: [
+        getCol('option_a') || getCol('a'),
+        getCol('option_b') || getCol('b'),
+        getCol('option_c') || getCol('c'),
+        getCol('option_d') || getCol('d'),
+      ],
+      correct_answer: correctAnswer,
+      subelement: getCol('subelement'),
+      question_group: getCol('question_group') || getCol('group'),
+      explanation: getCol('explanation') || undefined,
+    });
+  }
+
+  return questions;
+}
+
+/**
+ * Parse JSON content into an array of ImportQuestion objects.
+ * Handles BOM (Byte Order Mark) if present.
+ * Supports both array format and { questions: [...] } format.
+ */
+export function parseJSON(content: string): ImportQuestion[] {
+  try {
+    // Remove BOM if present
+    const cleanContent = content.replace(/^\uFEFF/, '');
+    const data = JSON.parse(cleanContent);
+    const questions = Array.isArray(data) ? data : data.questions || [];
+
+    return questions.map((q: Record<string, unknown>) => ({
+      id: String(q.id || ''),
+      question: String(q.question || ''),
+      options: Array.isArray(q.options) ? q.options.map(String) : [
+        String(q.option_a || q.a || ''),
+        String(q.option_b || q.b || ''),
+        String(q.option_c || q.c || ''),
+        String(q.option_d || q.d || ''),
+      ],
+      correct_answer: typeof q.correct_answer === 'number' ? q.correct_answer :
+        ['a', '0'].includes(String(q.correct_answer).toLowerCase()) ? 0 :
+        ['b', '1'].includes(String(q.correct_answer).toLowerCase()) ? 1 :
+        ['c', '2'].includes(String(q.correct_answer).toLowerCase()) ? 2 :
+        ['d', '3'].includes(String(q.correct_answer).toLowerCase()) ? 3 : 0,
+      subelement: String(q.subelement || ''),
+      question_group: String(q.question_group || q.group || ''),
+      explanation: q.explanation ? String(q.explanation) : undefined,
+      links: Array.isArray(q.links) ? q.links : undefined,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Validate an array of questions for a specific test type.
+ * Returns valid questions and any validation errors.
+ */
+export function validateQuestions(
+  questions: ImportQuestion[],
+  testType: TestType
+): ValidationResult {
+  const prefix = TEST_TYPE_PREFIXES[testType];
+  const valid: ImportQuestion[] = [];
+  const errors: { row: number; id?: string; errors: string[] }[] = [];
+
+  questions.forEach((q, index) => {
+    const rowErrors: string[] = [];
+
+    if (!q.id) rowErrors.push('Missing ID');
+    else if (!q.id.toUpperCase().startsWith(prefix)) {
+      rowErrors.push(`ID must start with "${prefix}" for ${testType} questions`);
+    }
+
+    if (!q.question) rowErrors.push('Missing question text');
+    if (!q.options || q.options.length !== 4) rowErrors.push('Must have exactly 4 options');
+    else if (q.options.some(o => !o?.trim())) rowErrors.push('All options must have text');
+
+    if (q.correct_answer < 0 || q.correct_answer > 3) rowErrors.push('Invalid correct answer');
+    if (!q.subelement) rowErrors.push('Missing subelement');
+    if (!q.question_group) rowErrors.push('Missing question group');
+
+    if (rowErrors.length > 0) {
+      errors.push({ row: index + 2, id: q.id, errors: rowErrors });
+    } else {
+      valid.push({
+        ...q,
+        id: q.id.toUpperCase().trim(),
+        question: q.question.trim(),
+        options: q.options.map(o => o.trim()),
+        subelement: q.subelement.trim(),
+        question_group: q.question_group.trim(),
+        explanation: q.explanation?.trim(),
+      });
+    }
+  });
+
+  return { valid, errors };
+}


### PR DESCRIPTION
The JSON parser had a regex that attempted to "fix" invalid escape sequences but was actually corrupting valid JSON files containing LaTeX notation like $\S 97.301(\text{d})$.

Changes:
- Remove problematic escape sequence transformation in parseJSON
- Extract parsing functions to questionImportParser.ts for testability
- Add comprehensive test suite (42 tests) covering:
  - CSV and JSON parsing
  - LaTeX math notation handling
  - Validation and normalization
  - Various answer format conversions (A-D, 0-3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)