### PR TITLE
Add branded email templates for Supabase Auth

### DIFF
--- a/email-templates/README.md
+++ b/email-templates/README.md
@@ -1,0 +1,70 @@
+# Email Templates for Open Ham Prep
+
+Custom email templates for Supabase Auth that match the Open Ham Prep design system.
+
+## Available Templates
+
+| Template | File | Supabase Setting |
+|----------|------|------------------|
+| Confirm Signup | `confirm-signup.html` | Authentication > Email Templates > Confirm signup |
+
+## How to Use in Supabase
+
+1. Go to your Supabase Dashboard
+2. Navigate to **Authentication** > **Email Templates**
+3. Select the template type (e.g., "Confirm signup")
+4. Copy the contents of the corresponding `.html` file
+5. Paste into the **Body** field (switch to "Source" mode first)
+6. Update the **Subject** field as needed
+7. Click **Save changes**
+
+## Available Template Variables
+
+These variables are provided by Supabase and can be used in templates:
+
+| Variable | Description |
+|----------|-------------|
+| `{{ .ConfirmationURL }}` | The full confirmation URL for the user to click |
+| `{{ .Token }}` | The raw confirmation token |
+| `{{ .TokenHash }}` | Hashed version of the token |
+| `{{ .SiteURL }}` | Your site URL (configured in Supabase) |
+| `{{ .Email }}` | The user's email address |
+| `{{ .Data }}` | Custom metadata passed during signup |
+| `{{ .RedirectTo }}` | Redirect URL after confirmation |
+
+## Design System
+
+The templates use colors and styling that match the Open Ham Prep app:
+
+### Colors (Dark Theme)
+- **Background**: `#0f172a` (slate-950)
+- **Card Background**: `#1e293b` (slate-800)
+- **Border**: `#334155` (slate-700)
+- **Primary (Amber)**: `#eab308`
+- **Primary Dark**: `#ca8a04`
+- **Text Primary**: `#f1f5f9` (slate-100)
+- **Text Secondary**: `#94a3b8` (slate-400)
+- **Text Muted**: `#64748b` (slate-500)
+
+### Typography
+- **Headings**: JetBrains Mono (monospace)
+- **Body**: System fonts (Apple, BlinkMac, Segoe UI, Roboto)
+
+## Testing
+
+To test your email templates:
+
+1. Use a tool like [Litmus](https://litmus.com/) or [Email on Acid](https://www.emailonacid.com/)
+2. Or simply sign up for a new account in your dev/staging environment
+3. Check how the email renders in various email clients
+
+## Email Client Compatibility
+
+These templates are designed to work with:
+- Gmail (Web, iOS, Android)
+- Apple Mail
+- Outlook (Web, Desktop, Mobile)
+- Yahoo Mail
+- Most modern email clients
+
+The templates use table-based layouts and inline styles for maximum compatibility.

--- a/email-templates/change-email.html
+++ b/email-templates/change-email.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Confirm Email Change - Open Ham Prep</title>
+  <!--[if mso]>
+  <noscript>
+    <xml>
+      <o:OfficeDocumentSettings>
+        <o:PixelsPerInch>96</o:PixelsPerInch>
+      </o:OfficeDocumentSettings>
+    </xml>
+  </noscript>
+  <![endif]-->
+  <style>
+    /* Reset styles */
+    body, table, td, p, a, li, blockquote {
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+    table, td {
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+    img {
+      -ms-interpolation-mode: bicubic;
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+    }
+    body {
+      margin: 0 !important;
+      padding: 0 !important;
+      width: 100% !important;
+    }
+
+    /* Client-specific styles */
+    @media only screen and (max-width: 600px) {
+      .container {
+        width: 100% !important;
+        padding: 16px !important;
+      }
+      .content-cell {
+        padding: 32px 24px !important;
+      }
+      .button {
+        width: 100% !important;
+        display: block !important;
+      }
+    }
+  </style>
+</head>
+<body style="margin: 0; padding: 0; background-color: #0f172a; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;">
+
+  <!-- Preview text -->
+  <div style="display: none; max-height: 0; overflow: hidden;">
+    Confirm your email address change for your Open Ham Prep account.
+  </div>
+
+  <!-- Main wrapper -->
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #0f172a;">
+    <tr>
+      <td align="center" style="padding: 40px 16px;">
+
+        <!-- Container -->
+        <table role="presentation" class="container" width="560" cellpadding="0" cellspacing="0" style="max-width: 560px;">
+
+          <!-- Logo Header -->
+          <tr>
+            <td align="center" style="padding-bottom: 32px;">
+              <table role="presentation" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="background: linear-gradient(135deg, rgba(234, 179, 8, 0.15) 0%, rgba(234, 179, 8, 0.05) 100%); border-radius: 12px; padding: 12px;">
+                    <!-- Radio wave icon -->
+                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M17.5 8C17.5 8 19 9.5 19 12C19 14.5 17.5 16 17.5 16" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M20.5 5C20.5 5 23 7.5 23 12C23 16.5 20.5 19 20.5 19" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M6.5 8C6.5 8 5 9.5 5 12C5 14.5 6.5 16 6.5 16" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M3.5 5C3.5 5 1 7.5 1 12C1 16.5 3.5 19 3.5 19" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <circle cx="12" cy="12" r="1.5" fill="#eab308" stroke="#eab308" stroke-width="1.5"/>
+                    </svg>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin: 16px 0 0 0; font-family: 'JetBrains Mono', 'Courier New', monospace; font-size: 20px; font-weight: 700; color: #f1f5f9; letter-spacing: -0.5px;">
+                Open Ham Prep
+              </p>
+            </td>
+          </tr>
+
+          <!-- Main Card -->
+          <tr>
+            <td>
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #1e293b; border: 1px solid #334155; border-radius: 16px; overflow: hidden;">
+
+                <!-- Card Content -->
+                <tr>
+                  <td class="content-cell" style="padding: 48px 40px;">
+
+                    <!-- Icon -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td align="center" style="padding-bottom: 24px;">
+                          <div style="width: 64px; height: 64px; background: linear-gradient(135deg, rgba(234, 179, 8, 0.2) 0%, rgba(234, 179, 8, 0.1) 100%); border-radius: 50%; display: inline-block; line-height: 64px; text-align: center;">
+                            <span style="font-size: 28px;">&#9993;</span>
+                          </div>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <!-- Heading -->
+                    <h1 style="margin: 0 0 16px 0; font-family: 'JetBrains Mono', 'Courier New', monospace; font-size: 24px; font-weight: 700; color: #f1f5f9; text-align: center; line-height: 1.3;">
+                      Confirm Email Change
+                    </h1>
+
+                    <!-- Description -->
+                    <p style="margin: 0 0 24px 0; font-size: 16px; line-height: 1.6; color: #94a3b8; text-align: center;">
+                      You requested to change your email address for your Open Ham Prep account.
+                    </p>
+
+                    <!-- Email Change Details -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-bottom: 32px;">
+                      <tr>
+                        <td style="background-color: #0f172a; border-radius: 8px; padding: 16px;">
+                          <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                            <tr>
+                              <td style="padding-bottom: 8px;">
+                                <span style="font-size: 13px; color: #64748b;">From:</span>
+                                <span style="font-size: 14px; color: #f1f5f9; font-family: 'JetBrains Mono', 'Courier New', monospace; margin-left: 8px;">{{ .Email }}</span>
+                              </td>
+                            </tr>
+                            <tr>
+                              <td>
+                                <span style="font-size: 13px; color: #64748b;">To:</span>
+                                <span style="font-size: 14px; color: #eab308; font-family: 'JetBrains Mono', 'Courier New', monospace; margin-left: 8px;">{{ .NewEmail }}</span>
+                              </td>
+                            </tr>
+                          </table>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <!-- CTA Button -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td align="center" style="padding-bottom: 32px;">
+                          <a href="{{ .ConfirmationURL }}" class="button" style="display: inline-block; background: linear-gradient(135deg, #eab308 0%, #ca8a04 100%); color: #0f172a; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; font-weight: 600; text-decoration: none; padding: 14px 32px; border-radius: 8px; box-shadow: 0 4px 14px rgba(234, 179, 8, 0.25);">
+                            Confirm Email Change
+                          </a>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <!-- Divider -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td style="border-top: 1px solid #334155; padding-top: 24px;">
+                          <p style="margin: 0 0 12px 0; font-size: 14px; color: #64748b; text-align: center;">
+                            Or copy and paste this link into your browser:
+                          </p>
+                          <p style="margin: 0; font-size: 13px; color: #eab308; word-break: break-all; text-align: center; font-family: 'JetBrains Mono', 'Courier New', monospace;">
+                            {{ .ConfirmationURL }}
+                          </p>
+                        </td>
+                      </tr>
+                    </table>
+
+                  </td>
+                </tr>
+
+              </table>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="padding-top: 32px;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center">
+                    <p style="margin: 0 0 8px 0; font-size: 13px; color: #64748b; line-height: 1.5;">
+                      This link will expire in 24 hours. If you didn't request this change, please secure your account immediately.
+                    </p>
+                    <p style="margin: 0; font-size: 13px; color: #475569;">
+                      &copy; Open Ham Prep &bull; openhamprep.app
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/email-templates/confirm-signup.html
+++ b/email-templates/confirm-signup.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Confirm Your Signup - Open Ham Prep</title>
+  <!--[if mso]>
+  <noscript>
+    <xml>
+      <o:OfficeDocumentSettings>
+        <o:PixelsPerInch>96</o:PixelsPerInch>
+      </o:OfficeDocumentSettings>
+    </xml>
+  </noscript>
+  <![endif]-->
+  <style>
+    /* Reset styles */
+    body, table, td, p, a, li, blockquote {
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+    table, td {
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+    img {
+      -ms-interpolation-mode: bicubic;
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+    }
+    body {
+      margin: 0 !important;
+      padding: 0 !important;
+      width: 100% !important;
+    }
+
+    /* Client-specific styles */
+    @media only screen and (max-width: 600px) {
+      .container {
+        width: 100% !important;
+        padding: 16px !important;
+      }
+      .content-cell {
+        padding: 32px 24px !important;
+      }
+      .button {
+        width: 100% !important;
+        display: block !important;
+      }
+    }
+  </style>
+</head>
+<body style="margin: 0; padding: 0; background-color: #0f172a; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;">
+
+  <!-- Preview text -->
+  <div style="display: none; max-height: 0; overflow: hidden;">
+    Welcome to Open Ham Prep! Please confirm your email to start studying for your amateur radio license.
+  </div>
+
+  <!-- Main wrapper -->
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #0f172a;">
+    <tr>
+      <td align="center" style="padding: 40px 16px;">
+
+        <!-- Container -->
+        <table role="presentation" class="container" width="560" cellpadding="0" cellspacing="0" style="max-width: 560px;">
+
+          <!-- Logo Header -->
+          <tr>
+            <td align="center" style="padding-bottom: 32px;">
+              <table role="presentation" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="background: linear-gradient(135deg, rgba(234, 179, 8, 0.15) 0%, rgba(234, 179, 8, 0.05) 100%); border-radius: 12px; padding: 12px;">
+                    <!-- Radio wave icon -->
+                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M17.5 8C17.5 8 19 9.5 19 12C19 14.5 17.5 16 17.5 16" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M20.5 5C20.5 5 23 7.5 23 12C23 16.5 20.5 19 20.5 19" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M6.5 8C6.5 8 5 9.5 5 12C5 14.5 6.5 16 6.5 16" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M3.5 5C3.5 5 1 7.5 1 12C1 16.5 3.5 19 3.5 19" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <circle cx="12" cy="12" r="1.5" fill="#eab308" stroke="#eab308" stroke-width="1.5"/>
+                    </svg>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin: 16px 0 0 0; font-family: 'JetBrains Mono', 'Courier New', monospace; font-size: 20px; font-weight: 700; color: #f1f5f9; letter-spacing: -0.5px;">
+                Open Ham Prep
+              </p>
+            </td>
+          </tr>
+
+          <!-- Main Card -->
+          <tr>
+            <td>
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #1e293b; border: 1px solid #334155; border-radius: 16px; overflow: hidden;">
+
+                <!-- Card Content -->
+                <tr>
+                  <td class="content-cell" style="padding: 48px 40px;">
+
+                    <!-- Icon -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td align="center" style="padding-bottom: 24px;">
+                          <div style="width: 64px; height: 64px; background: linear-gradient(135deg, rgba(234, 179, 8, 0.2) 0%, rgba(234, 179, 8, 0.1) 100%); border-radius: 50%; display: inline-block; line-height: 64px; text-align: center;">
+                            <span style="font-size: 28px;">&#9993;</span>
+                          </div>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <!-- Heading -->
+                    <h1 style="margin: 0 0 16px 0; font-family: 'JetBrains Mono', 'Courier New', monospace; font-size: 24px; font-weight: 700; color: #f1f5f9; text-align: center; line-height: 1.3;">
+                      Confirm Your Email
+                    </h1>
+
+                    <!-- Description -->
+                    <p style="margin: 0 0 32px 0; font-size: 16px; line-height: 1.6; color: #94a3b8; text-align: center;">
+                      Thanks for signing up for Open Ham Prep! Click the button below to verify your email address and start your journey to getting your amateur radio license.
+                    </p>
+
+                    <!-- CTA Button -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td align="center" style="padding-bottom: 32px;">
+                          <a href="{{ .ConfirmationURL }}" class="button" style="display: inline-block; background: linear-gradient(135deg, #eab308 0%, #ca8a04 100%); color: #0f172a; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; font-weight: 600; text-decoration: none; padding: 14px 32px; border-radius: 8px; box-shadow: 0 4px 14px rgba(234, 179, 8, 0.25);">
+                            Verify Email Address
+                          </a>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <!-- Divider -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td style="border-top: 1px solid #334155; padding-top: 24px;">
+                          <p style="margin: 0 0 12px 0; font-size: 14px; color: #64748b; text-align: center;">
+                            Or copy and paste this link into your browser:
+                          </p>
+                          <p style="margin: 0; font-size: 13px; color: #eab308; word-break: break-all; text-align: center; font-family: 'JetBrains Mono', 'Courier New', monospace;">
+                            {{ .ConfirmationURL }}
+                          </p>
+                        </td>
+                      </tr>
+                    </table>
+
+                  </td>
+                </tr>
+
+              </table>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="padding-top: 32px;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center">
+                    <p style="margin: 0 0 8px 0; font-size: 13px; color: #64748b; line-height: 1.5;">
+                      This link will expire in 24 hours. If you didn't create an account with Open Ham Prep, you can safely ignore this email.
+                    </p>
+                    <p style="margin: 0; font-size: 13px; color: #475569;">
+                      &copy; Open Ham Prep &bull; openhamprep.app
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/email-templates/email-changed.html
+++ b/email-templates/email-changed.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Your Email Address Has Been Changed - Open Ham Prep</title>
+  <!--[if mso]>
+  <noscript>
+    <xml>
+      <o:OfficeDocumentSettings>
+        <o:PixelsPerInch>96</o:PixelsPerInch>
+      </o:OfficeDocumentSettings>
+    </xml>
+  </noscript>
+  <![endif]-->
+  <style>
+    /* Reset styles */
+    body, table, td, p, a, li, blockquote {
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+    table, td {
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+    img {
+      -ms-interpolation-mode: bicubic;
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+    }
+    body {
+      margin: 0 !important;
+      padding: 0 !important;
+      width: 100% !important;
+    }
+
+    /* Client-specific styles */
+    @media only screen and (max-width: 600px) {
+      .container {
+        width: 100% !important;
+        padding: 16px !important;
+      }
+      .content-cell {
+        padding: 32px 24px !important;
+      }
+    }
+  </style>
+</head>
+<body style="margin: 0; padding: 0; background-color: #0f172a; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;">
+
+  <!-- Preview text -->
+  <div style="display: none; max-height: 0; overflow: hidden;">
+    Your Open Ham Prep email address has been successfully changed.
+  </div>
+
+  <!-- Main wrapper -->
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #0f172a;">
+    <tr>
+      <td align="center" style="padding: 40px 16px;">
+
+        <!-- Container -->
+        <table role="presentation" class="container" width="560" cellpadding="0" cellspacing="0" style="max-width: 560px;">
+
+          <!-- Logo Header -->
+          <tr>
+            <td align="center" style="padding-bottom: 32px;">
+              <table role="presentation" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="background: linear-gradient(135deg, rgba(234, 179, 8, 0.15) 0%, rgba(234, 179, 8, 0.05) 100%); border-radius: 12px; padding: 12px;">
+                    <!-- Radio wave icon -->
+                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M17.5 8C17.5 8 19 9.5 19 12C19 14.5 17.5 16 17.5 16" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M20.5 5C20.5 5 23 7.5 23 12C23 16.5 20.5 19 20.5 19" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M6.5 8C6.5 8 5 9.5 5 12C5 14.5 6.5 16 6.5 16" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M3.5 5C3.5 5 1 7.5 1 12C1 16.5 3.5 19 3.5 19" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <circle cx="12" cy="12" r="1.5" fill="#eab308" stroke="#eab308" stroke-width="1.5"/>
+                    </svg>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin: 16px 0 0 0; font-family: 'JetBrains Mono', 'Courier New', monospace; font-size: 20px; font-weight: 700; color: #f1f5f9; letter-spacing: -0.5px;">
+                Open Ham Prep
+              </p>
+            </td>
+          </tr>
+
+          <!-- Main Card -->
+          <tr>
+            <td>
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #1e293b; border: 1px solid #334155; border-radius: 16px; overflow: hidden;">
+
+                <!-- Card Content -->
+                <tr>
+                  <td class="content-cell" style="padding: 48px 40px;">
+
+                    <!-- Icon -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td align="center" style="padding-bottom: 24px;">
+                          <div style="width: 64px; height: 64px; background: linear-gradient(135deg, rgba(34, 197, 94, 0.2) 0%, rgba(34, 197, 94, 0.1) 100%); border-radius: 50%; display: inline-block; line-height: 64px; text-align: center;">
+                            <span style="font-size: 28px;">&#9989;</span>
+                          </div>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <!-- Heading -->
+                    <h1 style="margin: 0 0 16px 0; font-family: 'JetBrains Mono', 'Courier New', monospace; font-size: 24px; font-weight: 700; color: #f1f5f9; text-align: center; line-height: 1.3;">
+                      Email Address Changed
+                    </h1>
+
+                    <!-- Description -->
+                    <p style="margin: 0 0 24px 0; font-size: 16px; line-height: 1.6; color: #94a3b8; text-align: center;">
+                      The email address for your Open Ham Prep account has been successfully changed.
+                    </p>
+
+                    <!-- Email Change Details -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-bottom: 32px;">
+                      <tr>
+                        <td style="background-color: #0f172a; border-radius: 8px; padding: 16px;">
+                          <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                            <tr>
+                              <td style="padding-bottom: 8px;">
+                                <span style="font-size: 13px; color: #64748b;">From:</span>
+                                <span style="font-size: 14px; color: #94a3b8; font-family: 'JetBrains Mono', 'Courier New', monospace; margin-left: 8px;">{{ .OldEmail }}</span>
+                              </td>
+                            </tr>
+                            <tr>
+                              <td>
+                                <span style="font-size: 13px; color: #64748b;">To:</span>
+                                <span style="font-size: 14px; color: #22c55e; font-family: 'JetBrains Mono', 'Courier New', monospace; margin-left: 8px;">{{ .Email }}</span>
+                              </td>
+                            </tr>
+                          </table>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <!-- Warning -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td style="background-color: rgba(239, 68, 68, 0.1); border: 1px solid rgba(239, 68, 68, 0.3); border-radius: 8px; padding: 16px;">
+                          <p style="margin: 0; font-size: 14px; color: #fca5a5; text-align: center; line-height: 1.6;">
+                            <strong style="color: #f87171;">Didn't make this change?</strong><br>
+                            If you did not change your email address, please contact support immediately.
+                          </p>
+                        </td>
+                      </tr>
+                    </table>
+
+                  </td>
+                </tr>
+
+              </table>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="padding-top: 32px;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center">
+                    <p style="margin: 0 0 8px 0; font-size: 13px; color: #64748b; line-height: 1.5;">
+                      This is an automated security notification for your account.
+                    </p>
+                    <p style="margin: 0; font-size: 13px; color: #475569;">
+                      &copy; Open Ham Prep &bull; openhamprep.app
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/email-templates/invite-user.html
+++ b/email-templates/invite-user.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>You've Been Invited - Open Ham Prep</title>
+  <!--[if mso]>
+  <noscript>
+    <xml>
+      <o:OfficeDocumentSettings>
+        <o:PixelsPerInch>96</o:PixelsPerInch>
+      </o:OfficeDocumentSettings>
+    </xml>
+  </noscript>
+  <![endif]-->
+  <style>
+    /* Reset styles */
+    body, table, td, p, a, li, blockquote {
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+    table, td {
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+    img {
+      -ms-interpolation-mode: bicubic;
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+    }
+    body {
+      margin: 0 !important;
+      padding: 0 !important;
+      width: 100% !important;
+    }
+
+    /* Client-specific styles */
+    @media only screen and (max-width: 600px) {
+      .container {
+        width: 100% !important;
+        padding: 16px !important;
+      }
+      .content-cell {
+        padding: 32px 24px !important;
+      }
+      .button {
+        width: 100% !important;
+        display: block !important;
+      }
+    }
+  </style>
+</head>
+<body style="margin: 0; padding: 0; background-color: #0f172a; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;">
+
+  <!-- Preview text -->
+  <div style="display: none; max-height: 0; overflow: hidden;">
+    You've been invited to join Open Ham Prep! Accept your invitation to start studying for your amateur radio license.
+  </div>
+
+  <!-- Main wrapper -->
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #0f172a;">
+    <tr>
+      <td align="center" style="padding: 40px 16px;">
+
+        <!-- Container -->
+        <table role="presentation" class="container" width="560" cellpadding="0" cellspacing="0" style="max-width: 560px;">
+
+          <!-- Logo Header -->
+          <tr>
+            <td align="center" style="padding-bottom: 32px;">
+              <table role="presentation" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="background: linear-gradient(135deg, rgba(234, 179, 8, 0.15) 0%, rgba(234, 179, 8, 0.05) 100%); border-radius: 12px; padding: 12px;">
+                    <!-- Radio wave icon -->
+                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M17.5 8C17.5 8 19 9.5 19 12C19 14.5 17.5 16 17.5 16" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M20.5 5C20.5 5 23 7.5 23 12C23 16.5 20.5 19 20.5 19" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M6.5 8C6.5 8 5 9.5 5 12C5 14.5 6.5 16 6.5 16" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M3.5 5C3.5 5 1 7.5 1 12C1 16.5 3.5 19 3.5 19" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <circle cx="12" cy="12" r="1.5" fill="#eab308" stroke="#eab308" stroke-width="1.5"/>
+                    </svg>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin: 16px 0 0 0; font-family: 'JetBrains Mono', 'Courier New', monospace; font-size: 20px; font-weight: 700; color: #f1f5f9; letter-spacing: -0.5px;">
+                Open Ham Prep
+              </p>
+            </td>
+          </tr>
+
+          <!-- Main Card -->
+          <tr>
+            <td>
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #1e293b; border: 1px solid #334155; border-radius: 16px; overflow: hidden;">
+
+                <!-- Card Content -->
+                <tr>
+                  <td class="content-cell" style="padding: 48px 40px;">
+
+                    <!-- Icon -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td align="center" style="padding-bottom: 24px;">
+                          <div style="width: 64px; height: 64px; background: linear-gradient(135deg, rgba(234, 179, 8, 0.2) 0%, rgba(234, 179, 8, 0.1) 100%); border-radius: 50%; display: inline-block; line-height: 64px; text-align: center;">
+                            <span style="font-size: 28px;">&#127881;</span>
+                          </div>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <!-- Heading -->
+                    <h1 style="margin: 0 0 16px 0; font-family: 'JetBrains Mono', 'Courier New', monospace; font-size: 24px; font-weight: 700; color: #f1f5f9; text-align: center; line-height: 1.3;">
+                      You've Been Invited!
+                    </h1>
+
+                    <!-- Description -->
+                    <p style="margin: 0 0 32px 0; font-size: 16px; line-height: 1.6; color: #94a3b8; text-align: center;">
+                      You've been invited to join Open Ham Prep, the best way to study for your FCC Amateur Radio license exam. Click below to accept your invitation and create your account.
+                    </p>
+
+                    <!-- CTA Button -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td align="center" style="padding-bottom: 32px;">
+                          <a href="{{ .ConfirmationURL }}" class="button" style="display: inline-block; background: linear-gradient(135deg, #eab308 0%, #ca8a04 100%); color: #0f172a; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; font-weight: 600; text-decoration: none; padding: 14px 32px; border-radius: 8px; box-shadow: 0 4px 14px rgba(234, 179, 8, 0.25);">
+                            Accept Invitation
+                          </a>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <!-- Divider -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td style="border-top: 1px solid #334155; padding-top: 24px;">
+                          <p style="margin: 0 0 12px 0; font-size: 14px; color: #64748b; text-align: center;">
+                            Or copy and paste this link into your browser:
+                          </p>
+                          <p style="margin: 0; font-size: 13px; color: #eab308; word-break: break-all; text-align: center; font-family: 'JetBrains Mono', 'Courier New', monospace;">
+                            {{ .ConfirmationURL }}
+                          </p>
+                        </td>
+                      </tr>
+                    </table>
+
+                  </td>
+                </tr>
+
+              </table>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="padding-top: 32px;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center">
+                    <p style="margin: 0 0 8px 0; font-size: 13px; color: #64748b; line-height: 1.5;">
+                      This invitation will expire in 24 hours. If you weren't expecting this invitation, you can safely ignore this email.
+                    </p>
+                    <p style="margin: 0; font-size: 13px; color: #475569;">
+                      &copy; Open Ham Prep &bull; openhamprep.app
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/email-templates/magic-link.html
+++ b/email-templates/magic-link.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Your Magic Link - Open Ham Prep</title>
+  <!--[if mso]>
+  <noscript>
+    <xml>
+      <o:OfficeDocumentSettings>
+        <o:PixelsPerInch>96</o:PixelsPerInch>
+      </o:OfficeDocumentSettings>
+    </xml>
+  </noscript>
+  <![endif]-->
+  <style>
+    /* Reset styles */
+    body, table, td, p, a, li, blockquote {
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+    table, td {
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+    img {
+      -ms-interpolation-mode: bicubic;
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+    }
+    body {
+      margin: 0 !important;
+      padding: 0 !important;
+      width: 100% !important;
+    }
+
+    /* Client-specific styles */
+    @media only screen and (max-width: 600px) {
+      .container {
+        width: 100% !important;
+        padding: 16px !important;
+      }
+      .content-cell {
+        padding: 32px 24px !important;
+      }
+      .button {
+        width: 100% !important;
+        display: block !important;
+      }
+    }
+  </style>
+</head>
+<body style="margin: 0; padding: 0; background-color: #0f172a; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;">
+
+  <!-- Preview text -->
+  <div style="display: none; max-height: 0; overflow: hidden;">
+    Your magic link to sign in to Open Ham Prep is ready. Click to log in instantly!
+  </div>
+
+  <!-- Main wrapper -->
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #0f172a;">
+    <tr>
+      <td align="center" style="padding: 40px 16px;">
+
+        <!-- Container -->
+        <table role="presentation" class="container" width="560" cellpadding="0" cellspacing="0" style="max-width: 560px;">
+
+          <!-- Logo Header -->
+          <tr>
+            <td align="center" style="padding-bottom: 32px;">
+              <table role="presentation" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="background: linear-gradient(135deg, rgba(234, 179, 8, 0.15) 0%, rgba(234, 179, 8, 0.05) 100%); border-radius: 12px; padding: 12px;">
+                    <!-- Radio wave icon -->
+                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M17.5 8C17.5 8 19 9.5 19 12C19 14.5 17.5 16 17.5 16" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M20.5 5C20.5 5 23 7.5 23 12C23 16.5 20.5 19 20.5 19" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M6.5 8C6.5 8 5 9.5 5 12C5 14.5 6.5 16 6.5 16" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M3.5 5C3.5 5 1 7.5 1 12C1 16.5 3.5 19 3.5 19" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <circle cx="12" cy="12" r="1.5" fill="#eab308" stroke="#eab308" stroke-width="1.5"/>
+                    </svg>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin: 16px 0 0 0; font-family: 'JetBrains Mono', 'Courier New', monospace; font-size: 20px; font-weight: 700; color: #f1f5f9; letter-spacing: -0.5px;">
+                Open Ham Prep
+              </p>
+            </td>
+          </tr>
+
+          <!-- Main Card -->
+          <tr>
+            <td>
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #1e293b; border: 1px solid #334155; border-radius: 16px; overflow: hidden;">
+
+                <!-- Card Content -->
+                <tr>
+                  <td class="content-cell" style="padding: 48px 40px;">
+
+                    <!-- Icon -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td align="center" style="padding-bottom: 24px;">
+                          <div style="width: 64px; height: 64px; background: linear-gradient(135deg, rgba(234, 179, 8, 0.2) 0%, rgba(234, 179, 8, 0.1) 100%); border-radius: 50%; display: inline-block; line-height: 64px; text-align: center;">
+                            <span style="font-size: 28px;">&#10024;</span>
+                          </div>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <!-- Heading -->
+                    <h1 style="margin: 0 0 16px 0; font-family: 'JetBrains Mono', 'Courier New', monospace; font-size: 24px; font-weight: 700; color: #f1f5f9; text-align: center; line-height: 1.3;">
+                      Your Magic Link
+                    </h1>
+
+                    <!-- Description -->
+                    <p style="margin: 0 0 32px 0; font-size: 16px; line-height: 1.6; color: #94a3b8; text-align: center;">
+                      Click the button below to sign in to your Open Ham Prep account instantly. No password needed!
+                    </p>
+
+                    <!-- CTA Button -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td align="center" style="padding-bottom: 32px;">
+                          <a href="{{ .ConfirmationURL }}" class="button" style="display: inline-block; background: linear-gradient(135deg, #eab308 0%, #ca8a04 100%); color: #0f172a; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; font-weight: 600; text-decoration: none; padding: 14px 32px; border-radius: 8px; box-shadow: 0 4px 14px rgba(234, 179, 8, 0.25);">
+                            Log In to Open Ham Prep
+                          </a>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <!-- Divider -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td style="border-top: 1px solid #334155; padding-top: 24px;">
+                          <p style="margin: 0 0 12px 0; font-size: 14px; color: #64748b; text-align: center;">
+                            Or copy and paste this link into your browser:
+                          </p>
+                          <p style="margin: 0; font-size: 13px; color: #eab308; word-break: break-all; text-align: center; font-family: 'JetBrains Mono', 'Courier New', monospace;">
+                            {{ .ConfirmationURL }}
+                          </p>
+                        </td>
+                      </tr>
+                    </table>
+
+                  </td>
+                </tr>
+
+              </table>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="padding-top: 32px;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center">
+                    <p style="margin: 0 0 8px 0; font-size: 13px; color: #64748b; line-height: 1.5;">
+                      This link will expire in 1 hour. If you didn't request this link, you can safely ignore this email.
+                    </p>
+                    <p style="margin: 0; font-size: 13px; color: #475569;">
+                      &copy; Open Ham Prep &bull; openhamprep.app
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/email-templates/mfa-enrolled.html
+++ b/email-templates/mfa-enrolled.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>MFA Factor Enrolled - Open Ham Prep</title>
+  <!--[if mso]>
+  <noscript>
+    <xml>
+      <o:OfficeDocumentSettings>
+        <o:PixelsPerInch>96</o:PixelsPerInch>
+      </o:OfficeDocumentSettings>
+    </xml>
+  </noscript>
+  <![endif]-->
+  <style>
+    /* Reset styles */
+    body, table, td, p, a, li, blockquote {
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+    table, td {
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+    img {
+      -ms-interpolation-mode: bicubic;
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+    }
+    body {
+      margin: 0 !important;
+      padding: 0 !important;
+      width: 100% !important;
+    }
+
+    /* Client-specific styles */
+    @media only screen and (max-width: 600px) {
+      .container {
+        width: 100% !important;
+        padding: 16px !important;
+      }
+      .content-cell {
+        padding: 32px 24px !important;
+      }
+    }
+  </style>
+</head>
+<body style="margin: 0; padding: 0; background-color: #0f172a; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;">
+
+  <!-- Preview text -->
+  <div style="display: none; max-height: 0; overflow: hidden;">
+    A new multi-factor authentication method has been added to your Open Ham Prep account.
+  </div>
+
+  <!-- Main wrapper -->
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #0f172a;">
+    <tr>
+      <td align="center" style="padding: 40px 16px;">
+
+        <!-- Container -->
+        <table role="presentation" class="container" width="560" cellpadding="0" cellspacing="0" style="max-width: 560px;">
+
+          <!-- Logo Header -->
+          <tr>
+            <td align="center" style="padding-bottom: 32px;">
+              <table role="presentation" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="background: linear-gradient(135deg, rgba(234, 179, 8, 0.15) 0%, rgba(234, 179, 8, 0.05) 100%); border-radius: 12px; padding: 12px;">
+                    <!-- Radio wave icon -->
+                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M17.5 8C17.5 8 19 9.5 19 12C19 14.5 17.5 16 17.5 16" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M20.5 5C20.5 5 23 7.5 23 12C23 16.5 20.5 19 20.5 19" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M6.5 8C6.5 8 5 9.5 5 12C5 14.5 6.5 16 6.5 16" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M3.5 5C3.5 5 1 7.5 1 12C1 16.5 3.5 19 3.5 19" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <circle cx="12" cy="12" r="1.5" fill="#eab308" stroke="#eab308" stroke-width="1.5"/>
+                    </svg>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin: 16px 0 0 0; font-family: 'JetBrains Mono', 'Courier New', monospace; font-size: 20px; font-weight: 700; color: #f1f5f9; letter-spacing: -0.5px;">
+                Open Ham Prep
+              </p>
+            </td>
+          </tr>
+
+          <!-- Main Card -->
+          <tr>
+            <td>
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #1e293b; border: 1px solid #334155; border-radius: 16px; overflow: hidden;">
+
+                <!-- Card Content -->
+                <tr>
+                  <td class="content-cell" style="padding: 48px 40px;">
+
+                    <!-- Icon -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td align="center" style="padding-bottom: 24px;">
+                          <div style="width: 64px; height: 64px; background: linear-gradient(135deg, rgba(34, 197, 94, 0.2) 0%, rgba(34, 197, 94, 0.1) 100%); border-radius: 50%; display: inline-block; line-height: 64px; text-align: center;">
+                            <span style="font-size: 28px;">&#128737;</span>
+                          </div>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <!-- Heading -->
+                    <h1 style="margin: 0 0 16px 0; font-family: 'JetBrains Mono', 'Courier New', monospace; font-size: 24px; font-weight: 700; color: #f1f5f9; text-align: center; line-height: 1.3;">
+                      MFA Factor Enrolled
+                    </h1>
+
+                    <!-- Description -->
+                    <p style="margin: 0 0 24px 0; font-size: 16px; line-height: 1.6; color: #94a3b8; text-align: center;">
+                      A new multi-factor authentication method has been added to your Open Ham Prep account. Your account is now more secure!
+                    </p>
+
+                    <!-- MFA Details -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-bottom: 32px;">
+                      <tr>
+                        <td style="background-color: #0f172a; border-radius: 8px; padding: 16px;">
+                          <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                            <tr>
+                              <td style="padding-bottom: 8px;">
+                                <span style="font-size: 13px; color: #64748b;">Account:</span>
+                                <span style="font-size: 14px; color: #f1f5f9; font-family: 'JetBrains Mono', 'Courier New', monospace; margin-left: 8px;">{{ .Email }}</span>
+                              </td>
+                            </tr>
+                            <tr>
+                              <td>
+                                <span style="font-size: 13px; color: #64748b;">Factor Type:</span>
+                                <span style="font-size: 14px; color: #22c55e; font-family: 'JetBrains Mono', 'Courier New', monospace; margin-left: 8px;">{{ .FactorType }}</span>
+                              </td>
+                            </tr>
+                          </table>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <!-- Warning -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td style="background-color: rgba(239, 68, 68, 0.1); border: 1px solid rgba(239, 68, 68, 0.3); border-radius: 8px; padding: 16px;">
+                          <p style="margin: 0; font-size: 14px; color: #fca5a5; text-align: center; line-height: 1.6;">
+                            <strong style="color: #f87171;">Didn't make this change?</strong><br>
+                            If you did not add this authentication method, please contact support immediately.
+                          </p>
+                        </td>
+                      </tr>
+                    </table>
+
+                  </td>
+                </tr>
+
+              </table>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="padding-top: 32px;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center">
+                    <p style="margin: 0 0 8px 0; font-size: 13px; color: #64748b; line-height: 1.5;">
+                      This is an automated security notification for your account.
+                    </p>
+                    <p style="margin: 0; font-size: 13px; color: #475569;">
+                      &copy; Open Ham Prep &bull; openhamprep.app
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/email-templates/mfa-unenrolled.html
+++ b/email-templates/mfa-unenrolled.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>MFA Factor Removed - Open Ham Prep</title>
+  <!--[if mso]>
+  <noscript>
+    <xml>
+      <o:OfficeDocumentSettings>
+        <o:PixelsPerInch>96</o:PixelsPerInch>
+      </o:OfficeDocumentSettings>
+    </xml>
+  </noscript>
+  <![endif]-->
+  <style>
+    /* Reset styles */
+    body, table, td, p, a, li, blockquote {
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+    table, td {
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+    img {
+      -ms-interpolation-mode: bicubic;
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+    }
+    body {
+      margin: 0 !important;
+      padding: 0 !important;
+      width: 100% !important;
+    }
+
+    /* Client-specific styles */
+    @media only screen and (max-width: 600px) {
+      .container {
+        width: 100% !important;
+        padding: 16px !important;
+      }
+      .content-cell {
+        padding: 32px 24px !important;
+      }
+    }
+  </style>
+</head>
+<body style="margin: 0; padding: 0; background-color: #0f172a; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;">
+
+  <!-- Preview text -->
+  <div style="display: none; max-height: 0; overflow: hidden;">
+    A multi-factor authentication method has been removed from your Open Ham Prep account.
+  </div>
+
+  <!-- Main wrapper -->
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #0f172a;">
+    <tr>
+      <td align="center" style="padding: 40px 16px;">
+
+        <!-- Container -->
+        <table role="presentation" class="container" width="560" cellpadding="0" cellspacing="0" style="max-width: 560px;">
+
+          <!-- Logo Header -->
+          <tr>
+            <td align="center" style="padding-bottom: 32px;">
+              <table role="presentation" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="background: linear-gradient(135deg, rgba(234, 179, 8, 0.15) 0%, rgba(234, 179, 8, 0.05) 100%); border-radius: 12px; padding: 12px;">
+                    <!-- Radio wave icon -->
+                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M17.5 8C17.5 8 19 9.5 19 12C19 14.5 17.5 16 17.5 16" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M20.5 5C20.5 5 23 7.5 23 12C23 16.5 20.5 19 20.5 19" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M6.5 8C6.5 8 5 9.5 5 12C5 14.5 6.5 16 6.5 16" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M3.5 5C3.5 5 1 7.5 1 12C1 16.5 3.5 19 3.5 19" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <circle cx="12" cy="12" r="1.5" fill="#eab308" stroke="#eab308" stroke-width="1.5"/>
+                    </svg>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin: 16px 0 0 0; font-family: 'JetBrains Mono', 'Courier New', monospace; font-size: 20px; font-weight: 700; color: #f1f5f9; letter-spacing: -0.5px;">
+                Open Ham Prep
+              </p>
+            </td>
+          </tr>
+
+          <!-- Main Card -->
+          <tr>
+            <td>
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #1e293b; border: 1px solid #334155; border-radius: 16px; overflow: hidden;">
+
+                <!-- Card Content -->
+                <tr>
+                  <td class="content-cell" style="padding: 48px 40px;">
+
+                    <!-- Icon -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td align="center" style="padding-bottom: 24px;">
+                          <div style="width: 64px; height: 64px; background: linear-gradient(135deg, rgba(251, 191, 36, 0.2) 0%, rgba(251, 191, 36, 0.1) 100%); border-radius: 50%; display: inline-block; line-height: 64px; text-align: center;">
+                            <span style="font-size: 28px;">&#9888;</span>
+                          </div>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <!-- Heading -->
+                    <h1 style="margin: 0 0 16px 0; font-family: 'JetBrains Mono', 'Courier New', monospace; font-size: 24px; font-weight: 700; color: #f1f5f9; text-align: center; line-height: 1.3;">
+                      MFA Factor Removed
+                    </h1>
+
+                    <!-- Description -->
+                    <p style="margin: 0 0 24px 0; font-size: 16px; line-height: 1.6; color: #94a3b8; text-align: center;">
+                      A multi-factor authentication method has been removed from your Open Ham Prep account.
+                    </p>
+
+                    <!-- MFA Details -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-bottom: 32px;">
+                      <tr>
+                        <td style="background-color: #0f172a; border-radius: 8px; padding: 16px;">
+                          <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                            <tr>
+                              <td style="padding-bottom: 8px;">
+                                <span style="font-size: 13px; color: #64748b;">Account:</span>
+                                <span style="font-size: 14px; color: #f1f5f9; font-family: 'JetBrains Mono', 'Courier New', monospace; margin-left: 8px;">{{ .Email }}</span>
+                              </td>
+                            </tr>
+                            <tr>
+                              <td>
+                                <span style="font-size: 13px; color: #64748b;">Factor Removed:</span>
+                                <span style="font-size: 14px; color: #fbbf24; font-family: 'JetBrains Mono', 'Courier New', monospace; margin-left: 8px;">{{ .FactorType }}</span>
+                              </td>
+                            </tr>
+                          </table>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <!-- Warning -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td style="background-color: rgba(239, 68, 68, 0.1); border: 1px solid rgba(239, 68, 68, 0.3); border-radius: 8px; padding: 16px;">
+                          <p style="margin: 0; font-size: 14px; color: #fca5a5; text-align: center; line-height: 1.6;">
+                            <strong style="color: #f87171;">Didn't make this change?</strong><br>
+                            If you did not remove this authentication method, please contact support immediately.
+                          </p>
+                        </td>
+                      </tr>
+                    </table>
+
+                  </td>
+                </tr>
+
+              </table>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="padding-top: 32px;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center">
+                    <p style="margin: 0 0 8px 0; font-size: 13px; color: #64748b; line-height: 1.5;">
+                      This is an automated security notification for your account.
+                    </p>
+                    <p style="margin: 0; font-size: 13px; color: #475569;">
+                      &copy; Open Ham Prep &bull; openhamprep.app
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/email-templates/password-changed.html
+++ b/email-templates/password-changed.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Your Password Has Been Changed - Open Ham Prep</title>
+  <!--[if mso]>
+  <noscript>
+    <xml>
+      <o:OfficeDocumentSettings>
+        <o:PixelsPerInch>96</o:PixelsPerInch>
+      </o:OfficeDocumentSettings>
+    </xml>
+  </noscript>
+  <![endif]-->
+  <style>
+    /* Reset styles */
+    body, table, td, p, a, li, blockquote {
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+    table, td {
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+    img {
+      -ms-interpolation-mode: bicubic;
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+    }
+    body {
+      margin: 0 !important;
+      padding: 0 !important;
+      width: 100% !important;
+    }
+
+    /* Client-specific styles */
+    @media only screen and (max-width: 600px) {
+      .container {
+        width: 100% !important;
+        padding: 16px !important;
+      }
+      .content-cell {
+        padding: 32px 24px !important;
+      }
+    }
+  </style>
+</head>
+<body style="margin: 0; padding: 0; background-color: #0f172a; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;">
+
+  <!-- Preview text -->
+  <div style="display: none; max-height: 0; overflow: hidden;">
+    Your Open Ham Prep password has been successfully changed.
+  </div>
+
+  <!-- Main wrapper -->
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #0f172a;">
+    <tr>
+      <td align="center" style="padding: 40px 16px;">
+
+        <!-- Container -->
+        <table role="presentation" class="container" width="560" cellpadding="0" cellspacing="0" style="max-width: 560px;">
+
+          <!-- Logo Header -->
+          <tr>
+            <td align="center" style="padding-bottom: 32px;">
+              <table role="presentation" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="background: linear-gradient(135deg, rgba(234, 179, 8, 0.15) 0%, rgba(234, 179, 8, 0.05) 100%); border-radius: 12px; padding: 12px;">
+                    <!-- Radio wave icon -->
+                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M17.5 8C17.5 8 19 9.5 19 12C19 14.5 17.5 16 17.5 16" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M20.5 5C20.5 5 23 7.5 23 12C23 16.5 20.5 19 20.5 19" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M6.5 8C6.5 8 5 9.5 5 12C5 14.5 6.5 16 6.5 16" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M3.5 5C3.5 5 1 7.5 1 12C1 16.5 3.5 19 3.5 19" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <circle cx="12" cy="12" r="1.5" fill="#eab308" stroke="#eab308" stroke-width="1.5"/>
+                    </svg>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin: 16px 0 0 0; font-family: 'JetBrains Mono', 'Courier New', monospace; font-size: 20px; font-weight: 700; color: #f1f5f9; letter-spacing: -0.5px;">
+                Open Ham Prep
+              </p>
+            </td>
+          </tr>
+
+          <!-- Main Card -->
+          <tr>
+            <td>
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #1e293b; border: 1px solid #334155; border-radius: 16px; overflow: hidden;">
+
+                <!-- Card Content -->
+                <tr>
+                  <td class="content-cell" style="padding: 48px 40px;">
+
+                    <!-- Icon -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td align="center" style="padding-bottom: 24px;">
+                          <div style="width: 64px; height: 64px; background: linear-gradient(135deg, rgba(34, 197, 94, 0.2) 0%, rgba(34, 197, 94, 0.1) 100%); border-radius: 50%; display: inline-block; line-height: 64px; text-align: center;">
+                            <span style="font-size: 28px;">&#9989;</span>
+                          </div>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <!-- Heading -->
+                    <h1 style="margin: 0 0 16px 0; font-family: 'JetBrains Mono', 'Courier New', monospace; font-size: 24px; font-weight: 700; color: #f1f5f9; text-align: center; line-height: 1.3;">
+                      Password Changed
+                    </h1>
+
+                    <!-- Description -->
+                    <p style="margin: 0 0 24px 0; font-size: 16px; line-height: 1.6; color: #94a3b8; text-align: center;">
+                      The password for your Open Ham Prep account has been successfully changed.
+                    </p>
+
+                    <!-- Account Info -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-bottom: 32px;">
+                      <tr>
+                        <td style="background-color: #0f172a; border-radius: 8px; padding: 16px;">
+                          <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                            <tr>
+                              <td align="center">
+                                <span style="font-size: 13px; color: #64748b;">Account:</span>
+                                <span style="font-size: 14px; color: #f1f5f9; font-family: 'JetBrains Mono', 'Courier New', monospace; margin-left: 8px;">{{ .Email }}</span>
+                              </td>
+                            </tr>
+                          </table>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <!-- Warning -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td style="background-color: rgba(239, 68, 68, 0.1); border: 1px solid rgba(239, 68, 68, 0.3); border-radius: 8px; padding: 16px;">
+                          <p style="margin: 0; font-size: 14px; color: #fca5a5; text-align: center; line-height: 1.6;">
+                            <strong style="color: #f87171;">Didn't make this change?</strong><br>
+                            If you did not change your password, please reset it immediately and contact support.
+                          </p>
+                        </td>
+                      </tr>
+                    </table>
+
+                  </td>
+                </tr>
+
+              </table>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="padding-top: 32px;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center">
+                    <p style="margin: 0 0 8px 0; font-size: 13px; color: #64748b; line-height: 1.5;">
+                      This is an automated security notification for your account.
+                    </p>
+                    <p style="margin: 0; font-size: 13px; color: #475569;">
+                      &copy; Open Ham Prep &bull; openhamprep.app
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/email-templates/reauthentication.html
+++ b/email-templates/reauthentication.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Confirm Reauthentication - Open Ham Prep</title>
+  <!--[if mso]>
+  <noscript>
+    <xml>
+      <o:OfficeDocumentSettings>
+        <o:PixelsPerInch>96</o:PixelsPerInch>
+      </o:OfficeDocumentSettings>
+    </xml>
+  </noscript>
+  <![endif]-->
+  <style>
+    /* Reset styles */
+    body, table, td, p, a, li, blockquote {
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+    table, td {
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+    img {
+      -ms-interpolation-mode: bicubic;
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+    }
+    body {
+      margin: 0 !important;
+      padding: 0 !important;
+      width: 100% !important;
+    }
+
+    /* Client-specific styles */
+    @media only screen and (max-width: 600px) {
+      .container {
+        width: 100% !important;
+        padding: 16px !important;
+      }
+      .content-cell {
+        padding: 32px 24px !important;
+      }
+    }
+  </style>
+</head>
+<body style="margin: 0; padding: 0; background-color: #0f172a; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;">
+
+  <!-- Preview text -->
+  <div style="display: none; max-height: 0; overflow: hidden;">
+    Your verification code for Open Ham Prep. Use this code to confirm your identity.
+  </div>
+
+  <!-- Main wrapper -->
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #0f172a;">
+    <tr>
+      <td align="center" style="padding: 40px 16px;">
+
+        <!-- Container -->
+        <table role="presentation" class="container" width="560" cellpadding="0" cellspacing="0" style="max-width: 560px;">
+
+          <!-- Logo Header -->
+          <tr>
+            <td align="center" style="padding-bottom: 32px;">
+              <table role="presentation" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="background: linear-gradient(135deg, rgba(234, 179, 8, 0.15) 0%, rgba(234, 179, 8, 0.05) 100%); border-radius: 12px; padding: 12px;">
+                    <!-- Radio wave icon -->
+                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M17.5 8C17.5 8 19 9.5 19 12C19 14.5 17.5 16 17.5 16" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M20.5 5C20.5 5 23 7.5 23 12C23 16.5 20.5 19 20.5 19" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M6.5 8C6.5 8 5 9.5 5 12C5 14.5 6.5 16 6.5 16" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M3.5 5C3.5 5 1 7.5 1 12C1 16.5 3.5 19 3.5 19" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <circle cx="12" cy="12" r="1.5" fill="#eab308" stroke="#eab308" stroke-width="1.5"/>
+                    </svg>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin: 16px 0 0 0; font-family: 'JetBrains Mono', 'Courier New', monospace; font-size: 20px; font-weight: 700; color: #f1f5f9; letter-spacing: -0.5px;">
+                Open Ham Prep
+              </p>
+            </td>
+          </tr>
+
+          <!-- Main Card -->
+          <tr>
+            <td>
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #1e293b; border: 1px solid #334155; border-radius: 16px; overflow: hidden;">
+
+                <!-- Card Content -->
+                <tr>
+                  <td class="content-cell" style="padding: 48px 40px;">
+
+                    <!-- Icon -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td align="center" style="padding-bottom: 24px;">
+                          <div style="width: 64px; height: 64px; background: linear-gradient(135deg, rgba(234, 179, 8, 0.2) 0%, rgba(234, 179, 8, 0.1) 100%); border-radius: 50%; display: inline-block; line-height: 64px; text-align: center;">
+                            <span style="font-size: 28px;">&#128272;</span>
+                          </div>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <!-- Heading -->
+                    <h1 style="margin: 0 0 16px 0; font-family: 'JetBrains Mono', 'Courier New', monospace; font-size: 24px; font-weight: 700; color: #f1f5f9; text-align: center; line-height: 1.3;">
+                      Verification Code
+                    </h1>
+
+                    <!-- Description -->
+                    <p style="margin: 0 0 32px 0; font-size: 16px; line-height: 1.6; color: #94a3b8; text-align: center;">
+                      Enter this code to verify your identity and complete your action on Open Ham Prep.
+                    </p>
+
+                    <!-- Code Display -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td align="center" style="padding-bottom: 32px;">
+                          <div style="background-color: #0f172a; border: 2px solid #eab308; border-radius: 12px; padding: 24px 48px; display: inline-block;">
+                            <span style="font-family: 'JetBrains Mono', 'Courier New', monospace; font-size: 32px; font-weight: 700; color: #eab308; letter-spacing: 8px;">{{ .Token }}</span>
+                          </div>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <!-- Instructions -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td style="border-top: 1px solid #334155; padding-top: 24px;">
+                          <p style="margin: 0; font-size: 14px; color: #64748b; text-align: center; line-height: 1.6;">
+                            Copy this code and paste it into the verification field in your browser. Do not share this code with anyone.
+                          </p>
+                        </td>
+                      </tr>
+                    </table>
+
+                  </td>
+                </tr>
+
+              </table>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="padding-top: 32px;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center">
+                    <p style="margin: 0 0 8px 0; font-size: 13px; color: #64748b; line-height: 1.5;">
+                      This code will expire in 10 minutes. If you didn't request this code, please secure your account immediately.
+                    </p>
+                    <p style="margin: 0; font-size: 13px; color: #475569;">
+                      &copy; Open Ham Prep &bull; openhamprep.app
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/email-templates/reset-password.html
+++ b/email-templates/reset-password.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Reset Your Password - Open Ham Prep</title>
+  <!--[if mso]>
+  <noscript>
+    <xml>
+      <o:OfficeDocumentSettings>
+        <o:PixelsPerInch>96</o:PixelsPerInch>
+      </o:OfficeDocumentSettings>
+    </xml>
+  </noscript>
+  <![endif]-->
+  <style>
+    /* Reset styles */
+    body, table, td, p, a, li, blockquote {
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+    table, td {
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+    img {
+      -ms-interpolation-mode: bicubic;
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+    }
+    body {
+      margin: 0 !important;
+      padding: 0 !important;
+      width: 100% !important;
+    }
+
+    /* Client-specific styles */
+    @media only screen and (max-width: 600px) {
+      .container {
+        width: 100% !important;
+        padding: 16px !important;
+      }
+      .content-cell {
+        padding: 32px 24px !important;
+      }
+      .button {
+        width: 100% !important;
+        display: block !important;
+      }
+    }
+  </style>
+</head>
+<body style="margin: 0; padding: 0; background-color: #0f172a; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;">
+
+  <!-- Preview text -->
+  <div style="display: none; max-height: 0; overflow: hidden;">
+    Reset your Open Ham Prep password. Click the link to create a new password.
+  </div>
+
+  <!-- Main wrapper -->
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #0f172a;">
+    <tr>
+      <td align="center" style="padding: 40px 16px;">
+
+        <!-- Container -->
+        <table role="presentation" class="container" width="560" cellpadding="0" cellspacing="0" style="max-width: 560px;">
+
+          <!-- Logo Header -->
+          <tr>
+            <td align="center" style="padding-bottom: 32px;">
+              <table role="presentation" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="background: linear-gradient(135deg, rgba(234, 179, 8, 0.15) 0%, rgba(234, 179, 8, 0.05) 100%); border-radius: 12px; padding: 12px;">
+                    <!-- Radio wave icon -->
+                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M17.5 8C17.5 8 19 9.5 19 12C19 14.5 17.5 16 17.5 16" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M20.5 5C20.5 5 23 7.5 23 12C23 16.5 20.5 19 20.5 19" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M6.5 8C6.5 8 5 9.5 5 12C5 14.5 6.5 16 6.5 16" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <path d="M3.5 5C3.5 5 1 7.5 1 12C1 16.5 3.5 19 3.5 19" stroke="#eab308" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                      <circle cx="12" cy="12" r="1.5" fill="#eab308" stroke="#eab308" stroke-width="1.5"/>
+                    </svg>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin: 16px 0 0 0; font-family: 'JetBrains Mono', 'Courier New', monospace; font-size: 20px; font-weight: 700; color: #f1f5f9; letter-spacing: -0.5px;">
+                Open Ham Prep
+              </p>
+            </td>
+          </tr>
+
+          <!-- Main Card -->
+          <tr>
+            <td>
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #1e293b; border: 1px solid #334155; border-radius: 16px; overflow: hidden;">
+
+                <!-- Card Content -->
+                <tr>
+                  <td class="content-cell" style="padding: 48px 40px;">
+
+                    <!-- Icon -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td align="center" style="padding-bottom: 24px;">
+                          <div style="width: 64px; height: 64px; background: linear-gradient(135deg, rgba(234, 179, 8, 0.2) 0%, rgba(234, 179, 8, 0.1) 100%); border-radius: 50%; display: inline-block; line-height: 64px; text-align: center;">
+                            <span style="font-size: 28px;">&#128274;</span>
+                          </div>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <!-- Heading -->
+                    <h1 style="margin: 0 0 16px 0; font-family: 'JetBrains Mono', 'Courier New', monospace; font-size: 24px; font-weight: 700; color: #f1f5f9; text-align: center; line-height: 1.3;">
+                      Reset Your Password
+                    </h1>
+
+                    <!-- Description -->
+                    <p style="margin: 0 0 32px 0; font-size: 16px; line-height: 1.6; color: #94a3b8; text-align: center;">
+                      We received a request to reset your password for your Open Ham Prep account. Click the button below to choose a new password.
+                    </p>
+
+                    <!-- CTA Button -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td align="center" style="padding-bottom: 32px;">
+                          <a href="{{ .ConfirmationURL }}" class="button" style="display: inline-block; background: linear-gradient(135deg, #eab308 0%, #ca8a04 100%); color: #0f172a; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; font-weight: 600; text-decoration: none; padding: 14px 32px; border-radius: 8px; box-shadow: 0 4px 14px rgba(234, 179, 8, 0.25);">
+                            Reset Password
+                          </a>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <!-- Divider -->
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td style="border-top: 1px solid #334155; padding-top: 24px;">
+                          <p style="margin: 0 0 12px 0; font-size: 14px; color: #64748b; text-align: center;">
+                            Or copy and paste this link into your browser:
+                          </p>
+                          <p style="margin: 0; font-size: 13px; color: #eab308; word-break: break-all; text-align: center; font-family: 'JetBrains Mono', 'Courier New', monospace;">
+                            {{ .ConfirmationURL }}
+                          </p>
+                        </td>
+                      </tr>
+                    </table>
+
+                  </td>
+                </tr>
+
+              </table>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="padding-top: 32px;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center">
+                    <p style="margin: 0 0 8px 0; font-size: 13px; color: #64748b; line-height: 1.5;">
+                      This link will expire in 1 hour. If you didn't request a password reset, you can safely ignore this email.
+                    </p>
+                    <p style="margin: 0; font-size: 13px; color: #475569;">
+                      &copy; Open Ham Prep &bull; openhamprep.app
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add 10 custom email templates matching the Open Ham Prep design system
- Templates use dark theme with amber/gold primary color to match app branding
- Include responsive design for mobile and compatibility with major email clients

## Templates Added
| Template | File | Purpose |
|----------|------|---------|
| Confirm Signup | `confirm-signup.html` | Email verification for new accounts |
| Invite User | `invite-user.html` | User invitation emails |
| Magic Link | `magic-link.html` | Passwordless login |
| Change Email | `change-email.html` | Email change confirmation |
| Reset Password | `reset-password.html` | Password reset requests |
| Reauthentication | `reauthentication.html` | Verification code display |
| Password Changed | `password-changed.html` | Password change notification |
| Email Changed | `email-changed.html` | Email change notification |
| MFA Enrolled | `mfa-enrolled.html` | MFA enrollment notification |
| MFA Unenrolled | `mfa-unenrolled.html` | MFA removal notification |

## Design Features
- Dark theme matching app design (`#0f172a` background, `#1e293b` cards)
- Amber/gold primary color (`#eab308`) for buttons and accents
- Radio wave logo icon matching the app favicon
- JetBrains Mono font for headings
- Responsive mobile design
- Email client compatibility (Outlook, Gmail, Apple Mail, etc.)
- Security warnings for sensitive account changes

## Test plan
- [ ] Copy each template into Supabase Dashboard > Authentication > Email Templates
- [ ] Test confirm signup flow with new user registration
- [ ] Test password reset flow
- [ ] Verify emails render correctly in Gmail, Outlook, and mobile clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)