### PR TITLE
Replace license dropdown with modal selector

### DIFF
--- a/src/components/BookmarkedQuestions.test.tsx
+++ b/src/components/BookmarkedQuestions.test.tsx
@@ -148,8 +148,8 @@ describe('BookmarkedQuestions', () => {
 
   describe('Empty State', () => {
     it('shows empty state when no bookmarks exist', () => {
-      // Override the mock to return empty bookmarks
-      mockBookmarksHook.mockReturnValueOnce({
+      // Override the mock to return empty bookmarks (use mockReturnValue to persist across re-renders)
+      mockBookmarksHook.mockReturnValue({
         bookmarks: [],
         isLoading: false,
         isBookmarked: vi.fn(() => false),
@@ -164,6 +164,17 @@ describe('BookmarkedQuestions', () => {
       expect(screen.getByText('No bookmarks yet')).toBeInTheDocument();
       expect(screen.getByText('Bookmark questions during practice to review them later')).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /start practicing/i })).toBeInTheDocument();
+
+      // Reset to default mock
+      mockBookmarksHook.mockReturnValue({
+        bookmarks: mockBookmarks,
+        isLoading: false,
+        isBookmarked: vi.fn((id: string) => mockBookmarks.some(b => b.question_id === id)),
+        addBookmark: { mutate: vi.fn() },
+        removeBookmark: mockRemoveBookmark,
+        getBookmarkNote: vi.fn((id: string) => mockBookmarks.find(b => b.question_id === id)?.note || null),
+        updateNote: { mutate: vi.fn() },
+      });
     });
   });
 
@@ -272,8 +283,8 @@ describe('BookmarkedQuestions', () => {
 
   describe('Loading State', () => {
     it('shows loading state when bookmarks are loading', () => {
-      // Override the mock to return loading state
-      mockBookmarksHook.mockReturnValueOnce({
+      // Override the mock to return loading state (use mockReturnValue to persist across re-renders)
+      mockBookmarksHook.mockReturnValue({
         bookmarks: undefined,
         isLoading: true,
         isBookmarked: vi.fn(() => false),
@@ -286,6 +297,17 @@ describe('BookmarkedQuestions', () => {
       renderBookmarkedQuestions();
 
       expect(screen.getByText(/loading bookmarks/i)).toBeInTheDocument();
+
+      // Reset to default mock
+      mockBookmarksHook.mockReturnValue({
+        bookmarks: mockBookmarks,
+        isLoading: false,
+        isBookmarked: vi.fn((id: string) => mockBookmarks.some(b => b.question_id === id)),
+        addBookmark: { mutate: vi.fn() },
+        removeBookmark: mockRemoveBookmark,
+        getBookmarkNote: vi.fn((id: string) => mockBookmarks.find(b => b.question_id === id)?.note || null),
+        updateNote: { mutate: vi.fn() },
+      });
     });
   });
 });

--- a/src/components/BookmarkedQuestions.tsx
+++ b/src/components/BookmarkedQuestions.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { QuestionCard } from "@/components/QuestionCard";
 import { useQuestions, Question } from "@/hooks/useQuestions";
@@ -36,6 +36,13 @@ export function BookmarkedQuestions({
   const bookmarkedQuestions = allQuestions?.filter(q => bookmarks?.some(b => b.question_id === q.id)) || [];
   const selectedQuestion = bookmarkedQuestions.find(q => q.id === selectedQuestionId);
   const selectedBookmark = bookmarks?.find(b => b.question_id === selectedQuestionId);
+
+  // Reset state when test type changes
+  useEffect(() => {
+    setSelectedQuestionId(null);
+    setSelectedAnswer(null);
+    setShowResult(false);
+  }, [testType]);
 
   // Keyboard shortcuts for bookmarked question view - must be before any early returns
   const handleAnswerSelect = (answer: 'A' | 'B' | 'C' | 'D') => {

--- a/src/components/DashboardSidebar.test.tsx
+++ b/src/components/DashboardSidebar.test.tsx
@@ -102,10 +102,102 @@ describe('DashboardSidebar', () => {
   });
 
   describe('License Class Selector', () => {
-    it('displays license class selector', () => {
+    it('displays license class label', () => {
       render(<DashboardSidebar {...defaultProps} />, { wrapper: createWrapper() });
 
       expect(screen.getByText('License Class')).toBeInTheDocument();
+    });
+
+    it('displays current license name', () => {
+      render(<DashboardSidebar {...defaultProps} selectedTest="technician" />, { wrapper: createWrapper() });
+
+      expect(screen.getByText('Technician')).toBeInTheDocument();
+    });
+
+    it('displays General when selected', () => {
+      render(<DashboardSidebar {...defaultProps} selectedTest="general" />, { wrapper: createWrapper() });
+
+      expect(screen.getByText('General')).toBeInTheDocument();
+    });
+
+    it('displays Amateur Extra when selected', () => {
+      render(<DashboardSidebar {...defaultProps} selectedTest="extra" />, { wrapper: createWrapper() });
+
+      expect(screen.getByText('Amateur Extra')).toBeInTheDocument();
+    });
+
+    it('opens license select modal when clicked', async () => {
+      const user = userEvent.setup();
+      render(<DashboardSidebar {...defaultProps} />, { wrapper: createWrapper() });
+
+      // Click the license selector button
+      const licenseButton = screen.getByText('Technician').closest('button');
+      await user.click(licenseButton!);
+
+      await waitFor(() => {
+        expect(screen.getByText('Select License Class')).toBeInTheDocument();
+      });
+    });
+
+    it('shows all license options in modal', async () => {
+      const user = userEvent.setup();
+      render(<DashboardSidebar {...defaultProps} />, { wrapper: createWrapper() });
+
+      // Click the license selector button
+      const licenseButton = screen.getByText('Technician').closest('button');
+      await user.click(licenseButton!);
+
+      await waitFor(() => {
+        expect(screen.getByText('Select License Class')).toBeInTheDocument();
+      });
+
+      // Check all three options are visible in modal
+      expect(screen.getByText(/Entry-level license/)).toBeInTheDocument();
+      expect(screen.getByText(/Expanded HF privileges/)).toBeInTheDocument();
+      expect(screen.getByText(/Full amateur privileges/)).toBeInTheDocument();
+    });
+
+    it('calls onTestChange when license is changed via modal', async () => {
+      const user = userEvent.setup();
+      const onTestChange = vi.fn();
+      render(<DashboardSidebar {...defaultProps} onTestChange={onTestChange} selectedTest="technician" />, { wrapper: createWrapper() });
+
+      // Open modal
+      const licenseButton = screen.getByText('Technician').closest('button');
+      await user.click(licenseButton!);
+
+      await waitFor(() => {
+        expect(screen.getByText('Select License Class')).toBeInTheDocument();
+      });
+
+      // Select General
+      const generalCard = screen.getByText(/Expanded HF privileges/).closest('button');
+      await user.click(generalCard!);
+
+      // Confirm change
+      await user.click(screen.getByRole('button', { name: /change license/i }));
+
+      expect(onTestChange).toHaveBeenCalledWith('general');
+    });
+
+    it('closes modal when Cancel is clicked', async () => {
+      const user = userEvent.setup();
+      render(<DashboardSidebar {...defaultProps} />, { wrapper: createWrapper() });
+
+      // Open modal
+      const licenseButton = screen.getByText('Technician').closest('button');
+      await user.click(licenseButton!);
+
+      await waitFor(() => {
+        expect(screen.getByText('Select License Class')).toBeInTheDocument();
+      });
+
+      // Click Cancel
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByText('Select License Class')).not.toBeInTheDocument();
+      });
     });
   });
 

--- a/src/components/DashboardSidebar.tsx
+++ b/src/components/DashboardSidebar.tsx
@@ -1,4 +1,4 @@
-import { Play, Zap, BookOpen, AlertTriangle, Bookmark, LogOut, Radio, PanelLeftClose, PanelLeft, BarChart3, Menu, Lock, ChevronDown, BookText, Shield, MapPin, Users, ExternalLink } from "lucide-react";
+import { Play, Zap, BookOpen, AlertTriangle, Bookmark, LogOut, Radio, PanelLeftClose, PanelLeft, BarChart3, Menu, Lock, ChevronDown, BookText, Shield, MapPin, Users, ExternalLink, Award } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -7,10 +7,10 @@ import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { ProfileModal } from "@/components/ProfileModal";
 import { useAdmin } from "@/hooks/useAdmin";
 import { useNavigate, useLocation } from "react-router-dom";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { useState } from "react";
 import { View, TestType, testTypes } from "@/types/navigation";
+import { LicenseSelectModal } from "@/components/LicenseSelectModal";
 interface NavItem {
   id: View;
   label: string;
@@ -55,6 +55,7 @@ export function DashboardSidebar({
   const [mobileOpen, setMobileOpen] = useState(false);
   const [profileModalOpen, setProfileModalOpen] = useState(false);
   const [signOutDialogOpen, setSignOutDialogOpen] = useState(false);
+  const [licenseModalOpen, setLicenseModalOpen] = useState(false);
   const {
     isAdmin
   } = useAdmin();
@@ -118,6 +119,13 @@ export function DashboardSidebar({
     }
   };
   const currentTest = testTypes.find(t => t.id === selectedTest);
+
+  const licenseIcons: Record<TestType, React.ElementType> = {
+    technician: Radio,
+    general: Zap,
+    extra: Award,
+  };
+  const CurrentLicenseIcon = licenseIcons[selectedTest];
   const NavContent = ({
     isMobile = false
   }: {
@@ -156,36 +164,29 @@ export function DashboardSidebar({
       <div className={cn("border-b border-border", !isMobile && isCollapsed ? "p-2" : "p-3")}>
         {isMobile || !isCollapsed ? <div>
             <label className="text-xs text-muted-foreground font-medium mb-1.5 block">License Class</label>
-            <Select value={selectedTest} onValueChange={v => {
-          const test = testTypes.find(t => t.id === v);
-          if (test?.available) {
-            onTestChange(v as TestType);
-          }
-        }}>
-              <SelectTrigger className="w-full bg-secondary/50 border-border">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent className="bg-card border-border z-50">
-                {testTypes.map(test => <SelectItem key={test.id} value={test.id} disabled={!test.available} className={cn(!test.available && "opacity-50 cursor-not-allowed")}>
-                    <span className="flex items-center gap-2">
-                      {test.name}
-                      {!test.available && <span className="text-[10px] text-muted-foreground ml-1">(Coming Soon)</span>}
-                    </span>
-                  </SelectItem>)}
-              </SelectContent>
-            </Select>
-            {!currentTest?.available && <span className="text-[10px] text-muted-foreground mt-1 block">
-                Coming Soon
-              </span>}
+            <button
+              onClick={() => setLicenseModalOpen(true)}
+              className="w-full flex items-center gap-3 p-2.5 rounded-lg bg-secondary/50 border border-border hover:bg-secondary hover:border-muted-foreground/50 transition-colors text-left"
+            >
+              <div className="flex-shrink-0 w-8 h-8 rounded-md bg-primary/10 flex items-center justify-center">
+                <CurrentLicenseIcon className="w-4 h-4 text-primary" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <span className="text-sm font-medium text-foreground">{currentTest?.name}</span>
+              </div>
+            </button>
           </div> : <Tooltip delayDuration={0}>
             <TooltipTrigger asChild>
-              <button className="w-full flex items-center justify-center p-2 rounded-lg bg-secondary/50 border border-border hover:bg-secondary transition-colors">
-                <span className="text-xs font-bold text-primary">{selectedTest[0].toUpperCase()}</span>
+              <button
+                onClick={() => setLicenseModalOpen(true)}
+                className="w-full flex items-center justify-center p-2 rounded-lg bg-secondary/50 border border-border hover:bg-secondary transition-colors"
+              >
+                <CurrentLicenseIcon className="w-4 h-4 text-primary" />
               </button>
             </TooltipTrigger>
             <TooltipContent side="right" className="bg-popover border-border">
               <p className="font-medium">{currentTest?.name}</p>
-              {!currentTest?.available && <p className="text-xs text-muted-foreground">Coming Soon</p>}
+              <p className="text-xs text-muted-foreground">Click to change</p>
             </TooltipContent>
           </Tooltip>}
       </div>
@@ -359,6 +360,14 @@ export function DashboardSidebar({
       displayName: userInfo.displayName,
       email: userInfo.email
     }} userId={userId} onProfileUpdate={onProfileUpdate} />}
+
+      {/* License Select Modal */}
+      <LicenseSelectModal
+        open={licenseModalOpen}
+        onOpenChange={setLicenseModalOpen}
+        selectedTest={selectedTest}
+        onTestChange={onTestChange}
+      />
 
       {/* Mobile Hamburger Button */}
       <div className="md:hidden fixed top-4 left-4 z-50">

--- a/src/components/LicenseSelectModal.test.tsx
+++ b/src/components/LicenseSelectModal.test.tsx
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { LicenseSelectModal } from './LicenseSelectModal';
+
+describe('LicenseSelectModal', () => {
+  const defaultProps = {
+    open: true,
+    onOpenChange: vi.fn(),
+    selectedTest: 'technician' as const,
+    onTestChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('renders the modal when open', () => {
+      render(<LicenseSelectModal {...defaultProps} />);
+
+      expect(screen.getByText('Select License Class')).toBeInTheDocument();
+      expect(screen.getByText('Choose which amateur radio license exam you want to study for.')).toBeInTheDocument();
+    });
+
+    it('does not render when closed', () => {
+      render(<LicenseSelectModal {...defaultProps} open={false} />);
+
+      expect(screen.queryByText('Select License Class')).not.toBeInTheDocument();
+    });
+
+    it('displays all three license options', () => {
+      render(<LicenseSelectModal {...defaultProps} />);
+
+      expect(screen.getByText('Technician')).toBeInTheDocument();
+      expect(screen.getByText('General')).toBeInTheDocument();
+      expect(screen.getByText('Amateur Extra')).toBeInTheDocument();
+    });
+
+    it('displays descriptions for each license', () => {
+      render(<LicenseSelectModal {...defaultProps} />);
+
+      expect(screen.getByText(/Entry-level license for new operators/)).toBeInTheDocument();
+      expect(screen.getByText(/Expanded HF privileges/)).toBeInTheDocument();
+      expect(screen.getByText(/Full amateur privileges/)).toBeInTheDocument();
+    });
+
+    it('displays question counts and passing scores', () => {
+      render(<LicenseSelectModal {...defaultProps} />);
+
+      // Technician and General: 35 questions, 26 to pass
+      expect(screen.getAllByText('35 questions').length).toBe(2);
+      expect(screen.getAllByText('26 to pass').length).toBe(2);
+
+      // Extra: 50 questions, 37 to pass
+      expect(screen.getByText('50 questions')).toBeInTheDocument();
+      expect(screen.getByText('37 to pass')).toBeInTheDocument();
+    });
+
+    it('shows "Current" badge on the currently selected license', () => {
+      render(<LicenseSelectModal {...defaultProps} selectedTest="general" />);
+
+      const generalCard = screen.getByText('General').closest('button');
+      expect(generalCard).toContainElement(screen.getByText('Current'));
+    });
+  });
+
+  describe('Selection Behavior', () => {
+    it('highlights the currently selected license card', () => {
+      render(<LicenseSelectModal {...defaultProps} selectedTest="technician" />);
+
+      const technicianCard = screen.getByText('Technician').closest('button');
+      expect(technicianCard).toHaveClass('border-primary');
+    });
+
+    it('allows selecting a different license', async () => {
+      const user = userEvent.setup();
+      render(<LicenseSelectModal {...defaultProps} selectedTest="technician" />);
+
+      const generalCard = screen.getByText('General').closest('button');
+      await user.click(generalCard!);
+
+      // The General card should now be highlighted
+      expect(generalCard).toHaveClass('border-primary');
+    });
+
+    it('updates pending selection when clicking a card', async () => {
+      const user = userEvent.setup();
+      render(<LicenseSelectModal {...defaultProps} selectedTest="technician" />);
+
+      // Click on Extra
+      const extraCard = screen.getByText('Amateur Extra').closest('button');
+      await user.click(extraCard!);
+
+      // Change button should be enabled since selection differs
+      expect(screen.getByRole('button', { name: /change license/i })).not.toBeDisabled();
+    });
+  });
+
+  describe('Confirm/Cancel Buttons', () => {
+    it('shows "No Change" when same license is selected', () => {
+      render(<LicenseSelectModal {...defaultProps} selectedTest="technician" />);
+
+      expect(screen.getByRole('button', { name: /no change/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /no change/i })).toBeDisabled();
+    });
+
+    it('shows "Change License" when different license is selected', async () => {
+      const user = userEvent.setup();
+      render(<LicenseSelectModal {...defaultProps} selectedTest="technician" />);
+
+      // Select General
+      const generalCard = screen.getByText('General').closest('button');
+      await user.click(generalCard!);
+
+      expect(screen.getByRole('button', { name: /change license/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /change license/i })).not.toBeDisabled();
+    });
+
+    it('calls onTestChange when Change License is clicked', async () => {
+      const user = userEvent.setup();
+      const onTestChange = vi.fn();
+      render(<LicenseSelectModal {...defaultProps} onTestChange={onTestChange} selectedTest="technician" />);
+
+      // Select General
+      const generalCard = screen.getByText('General').closest('button');
+      await user.click(generalCard!);
+
+      // Click Change License
+      await user.click(screen.getByRole('button', { name: /change license/i }));
+
+      expect(onTestChange).toHaveBeenCalledWith('general');
+    });
+
+    it('calls onOpenChange(false) when Change License is clicked', async () => {
+      const user = userEvent.setup();
+      const onOpenChange = vi.fn();
+      render(<LicenseSelectModal {...defaultProps} onOpenChange={onOpenChange} selectedTest="technician" />);
+
+      // Select General
+      const generalCard = screen.getByText('General').closest('button');
+      await user.click(generalCard!);
+
+      // Click Change License
+      await user.click(screen.getByRole('button', { name: /change license/i }));
+
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it('does not call onTestChange when Cancel is clicked', async () => {
+      const user = userEvent.setup();
+      const onTestChange = vi.fn();
+      render(<LicenseSelectModal {...defaultProps} onTestChange={onTestChange} selectedTest="technician" />);
+
+      // Select General
+      const generalCard = screen.getByText('General').closest('button');
+      await user.click(generalCard!);
+
+      // Click Cancel
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+      expect(onTestChange).not.toHaveBeenCalled();
+    });
+
+    it('calls onOpenChange(false) when Cancel is clicked', async () => {
+      const user = userEvent.setup();
+      const onOpenChange = vi.fn();
+      render(<LicenseSelectModal {...defaultProps} onOpenChange={onOpenChange} />);
+
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('Modal State Reset', () => {
+    it('resets pending selection when Cancel is clicked and modal reopens', async () => {
+      const user = userEvent.setup();
+      const onOpenChange = vi.fn();
+      render(<LicenseSelectModal {...defaultProps} selectedTest="technician" onOpenChange={onOpenChange} />);
+
+      // Select General
+      const generalCard = screen.getByText('General').closest('button');
+      await user.click(generalCard!);
+
+      // Verify General is now highlighted
+      expect(generalCard).toHaveClass('border-primary');
+
+      // Click Cancel - this should reset the pending selection
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+      // Verify onOpenChange was called to close
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it('preserves current selection in pending state when modal opens', () => {
+      // When modal opens with technician selected, technician should be pending selection
+      render(<LicenseSelectModal {...defaultProps} selectedTest="technician" />);
+
+      const technicianCard = screen.getByText('Technician').closest('button');
+      expect(technicianCard).toHaveClass('border-primary');
+    });
+
+    it('starts with correct pending selection for general', () => {
+      render(<LicenseSelectModal {...defaultProps} selectedTest="general" />);
+
+      const generalCard = screen.getByText('General').closest('button');
+      expect(generalCard).toHaveClass('border-primary');
+    });
+
+    it('starts with correct pending selection for extra', () => {
+      render(<LicenseSelectModal {...defaultProps} selectedTest="extra" />);
+
+      const extraCard = screen.getByText('Amateur Extra').closest('button');
+      expect(extraCard).toHaveClass('border-primary');
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('has accessible dialog title', () => {
+      render(<LicenseSelectModal {...defaultProps} />);
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByText('Select License Class')).toBeInTheDocument();
+    });
+
+    it('has accessible dialog description', () => {
+      render(<LicenseSelectModal {...defaultProps} />);
+
+      expect(screen.getByText('Choose which amateur radio license exam you want to study for.')).toBeInTheDocument();
+    });
+
+    it('license cards are buttons', () => {
+      render(<LicenseSelectModal {...defaultProps} />);
+
+      const buttons = screen.getAllByRole('button');
+      // Should have Cancel, Change/No Change buttons, plus 3 license cards, plus close button
+      expect(buttons.length).toBeGreaterThanOrEqual(5);
+    });
+  });
+
+  describe('Extra License Selection', () => {
+    it('allows selecting Extra license', async () => {
+      const user = userEvent.setup();
+      const onTestChange = vi.fn();
+      render(<LicenseSelectModal {...defaultProps} onTestChange={onTestChange} selectedTest="technician" />);
+
+      // Select Extra
+      const extraCard = screen.getByText('Amateur Extra').closest('button');
+      await user.click(extraCard!);
+
+      // Confirm
+      await user.click(screen.getByRole('button', { name: /change license/i }));
+
+      expect(onTestChange).toHaveBeenCalledWith('extra');
+    });
+
+    it('displays correct info for Extra license', () => {
+      render(<LicenseSelectModal {...defaultProps} selectedTest="extra" />);
+
+      expect(screen.getByText('50 questions')).toBeInTheDocument();
+      expect(screen.getByText('37 to pass')).toBeInTheDocument();
+      expect(screen.getByText(/Full amateur privileges/)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/LicenseSelectModal.tsx
+++ b/src/components/LicenseSelectModal.tsx
@@ -1,0 +1,163 @@
+import { useState } from "react";
+import { Radio, Zap, Award, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { TestType, testTypes, testConfig } from "@/types/navigation";
+
+interface LicenseSelectModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  selectedTest: TestType;
+  onTestChange: (test: TestType) => void;
+}
+
+const licenseIcons: Record<TestType, React.ElementType> = {
+  technician: Radio,
+  general: Zap,
+  extra: Award,
+};
+
+const licenseDescriptions: Record<TestType, string> = {
+  technician: "Entry-level license for new operators. 35 questions, need 26 to pass.",
+  general: "Expanded HF privileges. 35 questions, need 26 to pass.",
+  extra: "Full amateur privileges. 50 questions, need 37 to pass.",
+};
+
+export function LicenseSelectModal({
+  open,
+  onOpenChange,
+  selectedTest,
+  onTestChange,
+}: LicenseSelectModalProps) {
+  const [pendingSelection, setPendingSelection] = useState<TestType>(selectedTest);
+
+  // Reset pending selection when modal opens
+  const handleOpenChange = (newOpen: boolean) => {
+    if (newOpen) {
+      setPendingSelection(selectedTest);
+    }
+    onOpenChange(newOpen);
+  };
+
+  const handleConfirm = () => {
+    if (pendingSelection !== selectedTest) {
+      onTestChange(pendingSelection);
+    }
+    onOpenChange(false);
+  };
+
+  const handleCancel = () => {
+    setPendingSelection(selectedTest);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Select License Class</DialogTitle>
+          <DialogDescription>
+            Choose which amateur radio license exam you want to study for.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-3 py-4">
+          {testTypes.map((test) => {
+            const Icon = licenseIcons[test.id];
+            const config = testConfig[test.id];
+            const isSelected = pendingSelection === test.id;
+            const isCurrent = selectedTest === test.id;
+
+            return (
+              <button
+                key={test.id}
+                onClick={() => test.available && setPendingSelection(test.id)}
+                disabled={!test.available}
+                className={cn(
+                  "relative flex items-start gap-4 p-4 rounded-lg border-2 transition-all text-left",
+                  isSelected
+                    ? "border-primary bg-primary/5"
+                    : "border-border hover:border-muted-foreground/50 hover:bg-secondary/50",
+                  !test.available && "opacity-50 cursor-not-allowed"
+                )}
+              >
+                {/* Icon */}
+                <div
+                  className={cn(
+                    "flex-shrink-0 w-12 h-12 rounded-lg flex items-center justify-center",
+                    isSelected
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-secondary text-muted-foreground"
+                  )}
+                >
+                  <Icon className="w-6 h-6" />
+                </div>
+
+                {/* Content */}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <h3
+                      className={cn(
+                        "font-semibold",
+                        isSelected ? "text-foreground" : "text-foreground"
+                      )}
+                    >
+                      {test.name}
+                    </h3>
+                    {isCurrent && (
+                      <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full">
+                        Current
+                      </span>
+                    )}
+                    {!test.available && (
+                      <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full">
+                        Coming Soon
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    {licenseDescriptions[test.id]}
+                  </p>
+                  <div className="flex items-center gap-4 mt-2 text-xs text-muted-foreground">
+                    <span>{config.questionCount} questions</span>
+                    <span>{config.passingScore} to pass</span>
+                    <span>74% passing</span>
+                  </div>
+                </div>
+
+                {/* Selection indicator */}
+                {isSelected && (
+                  <div className="absolute top-4 right-4">
+                    <div className="w-5 h-5 rounded-full bg-primary flex items-center justify-center">
+                      <ChevronRight className="w-3 h-3 text-primary-foreground" />
+                    </div>
+                  </div>
+                )}
+              </button>
+            );
+          })}
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button variant="outline" onClick={handleCancel}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleConfirm}
+            disabled={pendingSelection === selectedTest}
+          >
+            {pendingSelection === selectedTest ? "No Change" : "Change License"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/PracticeTest.test.tsx
+++ b/src/components/PracticeTest.test.tsx
@@ -322,8 +322,8 @@ describe('PracticeTest', () => {
 
 describe('PracticeTest Loading State', () => {
   it('shows loading state when questions are loading', () => {
-    // Override the mock to return loading state
-    mockQuestionsHook.mockReturnValueOnce({
+    // Override the mock to return loading state (use mockReturnValue to persist across re-renders)
+    mockQuestionsHook.mockReturnValue({
       data: undefined,
       isLoading: true,
       error: null,
@@ -332,5 +332,12 @@ describe('PracticeTest Loading State', () => {
     renderPracticeTest();
 
     expect(screen.getByText(/loading/i)).toBeInTheDocument();
+
+    // Reset to default mock
+    mockQuestionsHook.mockReturnValue({
+      data: mockQuestions,
+      isLoading: false,
+      error: null,
+    });
   });
 });

--- a/src/components/PracticeTest.tsx
+++ b/src/components/PracticeTest.tsx
@@ -70,6 +70,17 @@ export function PracticeTest({
     onTestStateChange?.(hasStarted && !isFinished);
   }, [hasStarted, isFinished, onTestStateChange]);
 
+  // Reset state when test type changes
+  useEffect(() => {
+    setHasStarted(false);
+    setQuestions([]);
+    setCurrentIndex(0);
+    setAnswers({});
+    setIsFinished(false);
+    setTimerEnabled(false);
+    setTimeRemaining(120 * 60);
+  }, [testType]);
+
   // Timer effect
   useEffect(() => {
     if (!timerEnabled || isFinished || !hasStarted) return;

--- a/src/components/RandomPractice.test.tsx
+++ b/src/components/RandomPractice.test.tsx
@@ -226,8 +226,8 @@ describe('RandomPractice', () => {
 
   describe('Loading and Error States', () => {
     it('shows loading state', () => {
-      // Override the mock to return loading state
-      mockQuestionsHook.mockReturnValueOnce({
+      // Override the mock to return loading state (use mockReturnValue to persist across re-renders)
+      mockQuestionsHook.mockReturnValue({
         data: undefined,
         isLoading: true,
         error: null,
@@ -237,6 +237,13 @@ describe('RandomPractice', () => {
 
       // Component should handle loading gracefully
       expect(screen.queryByText(/loading/i)).toBeInTheDocument();
+
+      // Reset to default mock
+      mockQuestionsHook.mockReturnValue({
+        data: mockQuestions,
+        isLoading: false,
+        error: null,
+      });
     });
   });
 

--- a/src/components/RandomPractice.tsx
+++ b/src/components/RandomPractice.tsx
@@ -94,6 +94,16 @@ export function RandomPractice({
     loadBestStreak();
   }, [user]);
 
+  // Reset state when test type changes
+  useEffect(() => {
+    setQuestionHistory([]);
+    setHistoryIndex(-1);
+    setAskedIds([]);
+    setStats({ correct: 0, total: 0 });
+    setStreak(0);
+    setBestStreak(allTimeBestStreak);
+  }, [testType]);
+
   // Save best streak to database when it's beaten
   const saveBestStreak = async (newBestStreak: number) => {
     if (!user) return;

--- a/src/components/SubelementPractice.test.tsx
+++ b/src/components/SubelementPractice.test.tsx
@@ -185,8 +185,8 @@ describe('SubelementPractice', () => {
 
   describe('Loading State', () => {
     it('shows loading state when questions are loading', () => {
-      // Override the mock to return loading state
-      mockQuestionsHook.mockReturnValueOnce({
+      // Override the mock to return loading state (use mockReturnValue to persist across re-renders)
+      mockQuestionsHook.mockReturnValue({
         data: undefined,
         isLoading: true,
         error: null,
@@ -195,13 +195,20 @@ describe('SubelementPractice', () => {
       renderSubelementPractice();
 
       expect(screen.getByText(/loading/i)).toBeInTheDocument();
+
+      // Reset to default mock
+      mockQuestionsHook.mockReturnValue({
+        data: mockQuestions,
+        isLoading: false,
+        error: null,
+      });
     });
   });
 
   describe('Error State', () => {
     it('shows error state when questions fail to load', () => {
-      // Override the mock to return error state
-      mockQuestionsHook.mockReturnValueOnce({
+      // Override the mock to return error state (use mockReturnValue to persist across re-renders)
+      mockQuestionsHook.mockReturnValue({
         data: undefined,
         isLoading: false,
         error: new Error('Failed to load'),
@@ -211,6 +218,13 @@ describe('SubelementPractice', () => {
 
       expect(screen.getByText(/failed to load/i)).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /go back/i })).toBeInTheDocument();
+
+      // Reset to default mock
+      mockQuestionsHook.mockReturnValue({
+        data: mockQuestions,
+        isLoading: false,
+        error: null,
+      });
     });
   });
 });

--- a/src/components/SubelementPractice.tsx
+++ b/src/components/SubelementPractice.tsx
@@ -100,6 +100,16 @@ export function SubelementPractice({
   const selectedAnswer = currentEntry?.selectedAnswer || null;
   const showResult = currentEntry?.showResult || false;
 
+  // Reset state when test type changes
+  useEffect(() => {
+    setSelectedSubelement(null);
+    setTopicView('list');
+    setQuestionHistory([]);
+    setHistoryIndex(-1);
+    setStats({ correct: 0, total: 0 });
+    setAskedIds([]);
+  }, [testType]);
+
   // Group questions by subelement
   const questionsBySubelement = useMemo(() => {
     if (!allQuestions) return {};

--- a/src/components/WeakQuestionsReview.tsx
+++ b/src/components/WeakQuestionsReview.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { QuestionCard } from "@/components/QuestionCard";
@@ -40,6 +40,15 @@ export function WeakQuestionsReview({
   });
   const [completed, setCompleted] = useState(false);
   const currentQuestion = weakQuestions[currentIndex];
+
+  // Reset state when test type changes
+  useEffect(() => {
+    setCurrentIndex(0);
+    setSelectedAnswer(null);
+    setShowResult(false);
+    setStats({ correct: 0, total: 0 });
+    setCompleted(false);
+  }, [testType]);
 
   const handleSelectAnswer = useCallback(async (answer: 'A' | 'B' | 'C' | 'D') => {
     if (showResult || !currentQuestion) return;


### PR DESCRIPTION
## Summary
- Replace the license class dropdown in the sidebar with a modal-based selector featuring cards for each license type
- Add unique icons for each license (Radio for Technician, Zap for General, Award for Extra)
- Fix bug where changing license type while in a practice mode didn't reset the questions

## Changes
- **New Component**: `LicenseSelectModal` - Modal with card UI for selecting license class
- **Updated**: `DashboardSidebar` - Replaced dropdown with clickable button that opens modal
- **Bug Fix**: Added state reset when `testType` changes in all practice components:
  - RandomPractice
  - SubelementPractice
  - PracticeTest
  - WeakQuestionsReview
  - BookmarkedQuestions

## Test plan
- [ ] Click license selector in sidebar - modal should open
- [ ] Select a different license and click "Change License" - license should update
- [ ] Click "Cancel" - modal should close without changes
- [ ] While in Random Practice, change license type - questions should reset to new license
- [ ] While in Study by Topic, change license type - should return to topic list with new subelements
- [ ] While in Practice Test (before starting), change license type - should show start screen
- [ ] Verify all 454 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)