### PR TITLE
Add onboarding tour for new users

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -16,9 +16,12 @@ interface AppLayoutProps {
   onViewChange: (view: View) => void;
   selectedTest: TestType;
   onTestChange: (test: TestType) => void;
+  mobileMenuOpen?: boolean;
+  onMobileMenuChange?: (open: boolean) => void;
+  isTourActive?: boolean;
 }
 
-export function AppLayout({ children, currentView, onViewChange, selectedTest, onTestChange }: AppLayoutProps) {
+export function AppLayout({ children, currentView, onViewChange, selectedTest, onTestChange, mobileMenuOpen, onMobileMenuChange, isTourActive }: AppLayoutProps) {
   const { user, loading: authLoading, signOut } = useAuth();
   const { bookmarks } = useBookmarks();
   const navigate = useNavigate();
@@ -114,6 +117,9 @@ export function AppLayout({ children, currentView, onViewChange, selectedTest, o
           onProfileUpdate={handleProfileUpdate}
           selectedTest={selectedTest}
           onTestChange={onTestChange}
+          mobileMenuOpen={mobileMenuOpen}
+          onMobileMenuChange={onMobileMenuChange}
+          isTourActive={isTourActive}
         />
         <div className="flex-1 overflow-y-auto pt-16 md:pt-0 flex flex-col">
           {children}

--- a/src/components/DashboardSidebar.tsx
+++ b/src/components/DashboardSidebar.tsx
@@ -36,6 +36,9 @@ interface DashboardSidebarProps {
   onProfileUpdate?: () => void;
   selectedTest: TestType;
   onTestChange: (test: TestType) => void;
+  mobileMenuOpen?: boolean;
+  onMobileMenuChange?: (open: boolean) => void;
+  isTourActive?: boolean;
 }
 export function DashboardSidebar({
   currentView,
@@ -50,9 +53,21 @@ export function DashboardSidebar({
   userId,
   onProfileUpdate,
   selectedTest,
-  onTestChange
+  onTestChange,
+  mobileMenuOpen,
+  onMobileMenuChange,
+  isTourActive,
 }: DashboardSidebarProps) {
-  const [mobileOpen, setMobileOpen] = useState(false);
+  // Use controlled state if provided, otherwise use local state
+  const [localMobileOpen, setLocalMobileOpen] = useState(false);
+  const mobileOpen = mobileMenuOpen !== undefined ? mobileMenuOpen : localMobileOpen;
+  const setMobileOpen = (open: boolean) => {
+    if (onMobileMenuChange) {
+      onMobileMenuChange(open);
+    } else {
+      setLocalMobileOpen(open);
+    }
+  };
   const [profileModalOpen, setProfileModalOpen] = useState(false);
   const [signOutDialogOpen, setSignOutDialogOpen] = useState(false);
   const [licenseModalOpen, setLicenseModalOpen] = useState(false);
@@ -372,7 +387,11 @@ export function DashboardSidebar({
 
       {/* Mobile Hamburger Button */}
       <div className="md:hidden fixed top-4 left-4 z-50">
-        <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
+        <Sheet open={mobileOpen} onOpenChange={(open) => {
+          // Prevent closing when tour is active
+          if (!open && isTourActive) return;
+          setMobileOpen(open);
+        }}>
           <Tooltip>
             <TooltipTrigger asChild>
               <SheetTrigger asChild>

--- a/src/components/WelcomeModal.test.tsx
+++ b/src/components/WelcomeModal.test.tsx
@@ -22,7 +22,7 @@ describe('WelcomeModal', () => {
       );
 
       expect(screen.getByText('Welcome to Open Ham Prep!')).toBeInTheDocument();
-      expect(screen.getByText("Let's get you set up. Which license are you studying for?")).toBeInTheDocument();
+      expect(screen.getByText('Which license are you studying for?')).toBeInTheDocument();
     });
 
     it('should not render when open is false', () => {
@@ -49,20 +49,6 @@ describe('WelcomeModal', () => {
       expect(screen.getByText('Technician')).toBeInTheDocument();
       expect(screen.getByText('General')).toBeInTheDocument();
       expect(screen.getByText('Amateur Extra')).toBeInTheDocument();
-    });
-
-    it('should display license descriptions', () => {
-      render(
-        <WelcomeModal
-          open={true}
-          onComplete={mockOnComplete}
-          onSkip={mockOnSkip}
-        />
-      );
-
-      expect(screen.getByText('Perfect for beginners. Start your ham radio journey here!')).toBeInTheDocument();
-      expect(screen.getByText('Expanded HF privileges for experienced operators.')).toBeInTheDocument();
-      expect(screen.getByText('Full amateur privileges. The ultimate license.')).toBeInTheDocument();
     });
 
     it('should display question counts and passing scores', () => {

--- a/src/components/WelcomeModal.tsx
+++ b/src/components/WelcomeModal.tsx
@@ -40,21 +40,21 @@ export function WelcomeModal({ open, onComplete, onSkip }: WelcomeModalProps) {
   return (
     <Dialog open={open} onOpenChange={() => {}}>
       <DialogContent
-        className="sm:max-w-lg"
+        className="w-[90vw] max-w-md p-4 sm:p-6"
         onPointerDownOutside={(e) => e.preventDefault()}
         onEscapeKeyDown={(e) => e.preventDefault()}
       >
-        <DialogHeader className="text-center pb-2">
-          <div className="mx-auto mb-4 w-16 h-16 rounded-full bg-primary/10 flex items-center justify-center">
-            <Sparkles className="w-8 h-8 text-primary" />
+        <DialogHeader className="text-center pb-1 sm:pb-2">
+          <div className="mx-auto mb-2 sm:mb-4 w-10 h-10 sm:w-14 sm:h-14 rounded-full bg-primary/10 flex items-center justify-center">
+            <Sparkles className="w-5 h-5 sm:w-7 sm:h-7 text-primary" />
           </div>
-          <DialogTitle className="text-2xl">Welcome to Open Ham Prep!</DialogTitle>
-          <DialogDescription className="text-base">
-            Let's get you set up. Which license are you studying for?
+          <DialogTitle className="text-lg sm:text-xl">Welcome to Open Ham Prep!</DialogTitle>
+          <DialogDescription className="text-xs sm:text-sm">
+            Which license are you studying for?
           </DialogDescription>
         </DialogHeader>
 
-        <div className="grid gap-3 py-4">
+        <div className="grid gap-2 py-2 sm:py-4">
           {testTypes.map((test) => {
             const Icon = licenseIcons[test.id];
             const config = testConfig[test.id];
@@ -66,7 +66,7 @@ export function WelcomeModal({ open, onComplete, onSkip }: WelcomeModalProps) {
                 onClick={() => test.available && setSelectedLicense(test.id)}
                 disabled={!test.available}
                 className={cn(
-                  "relative flex items-start gap-4 p-4 rounded-lg border-2 transition-all text-left",
+                  "relative flex items-center gap-3 p-3 rounded-lg border-2 transition-all text-left",
                   isSelected
                     ? "border-primary bg-primary/5"
                     : "border-border hover:border-muted-foreground/50 hover:bg-secondary/50",
@@ -76,24 +76,21 @@ export function WelcomeModal({ open, onComplete, onSkip }: WelcomeModalProps) {
                 {/* Icon */}
                 <div
                   className={cn(
-                    "flex-shrink-0 w-12 h-12 rounded-lg flex items-center justify-center",
+                    "flex-shrink-0 w-10 h-10 rounded-lg flex items-center justify-center",
                     isSelected
                       ? "bg-primary text-primary-foreground"
                       : "bg-secondary text-muted-foreground"
                   )}
                 >
-                  <Icon className="w-6 h-6" />
+                  <Icon className="w-5 h-5" />
                 </div>
 
                 {/* Content */}
                 <div className="flex-1 min-w-0">
-                  <h3 className="font-semibold text-foreground">
+                  <h3 className="font-semibold text-foreground text-sm sm:text-base">
                     {test.name}
                   </h3>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    {licenseDescriptions[test.id]}
-                  </p>
-                  <div className="flex items-center gap-4 mt-2 text-xs text-muted-foreground">
+                  <div className="flex items-center gap-3 text-xs text-muted-foreground">
                     <span>{config.questionCount} questions</span>
                     <span>{config.passingScore} to pass</span>
                   </div>
@@ -101,7 +98,7 @@ export function WelcomeModal({ open, onComplete, onSkip }: WelcomeModalProps) {
 
                 {/* Selection indicator */}
                 {isSelected && (
-                  <div className="absolute top-4 right-4">
+                  <div className="flex-shrink-0">
                     <div className="w-5 h-5 rounded-full bg-primary flex items-center justify-center">
                       <div className="w-2 h-2 rounded-full bg-primary-foreground" />
                     </div>
@@ -112,15 +109,16 @@ export function WelcomeModal({ open, onComplete, onSkip }: WelcomeModalProps) {
           })}
         </div>
 
-        <DialogFooter className="flex-col sm:flex-row gap-2">
+        <DialogFooter className="flex-col sm:flex-row gap-2 pt-2">
           <Button
             variant="ghost"
             onClick={onSkip}
-            className="text-muted-foreground"
+            className="text-muted-foreground text-sm"
+            size="sm"
           >
             Skip tour
           </Button>
-          <Button onClick={handleContinue} className="gap-2">
+          <Button onClick={handleContinue} className="gap-2" size="sm">
             Continue
             <Sparkles className="w-4 h-4" />
           </Button>

--- a/src/hooks/useAppTour.tsx
+++ b/src/hooks/useAppTour.tsx
@@ -5,250 +5,224 @@ import 'shepherd.js/dist/css/shepherd.css';
 interface UseAppTourOptions {
   onComplete?: () => void;
   onCancel?: () => void;
+  onOpenMobileMenu?: () => void;
+  onCloseMobileMenu?: () => void;
 }
 
-export function useAppTour({ onComplete, onCancel }: UseAppTourOptions = {}) {
+// Check if we're on mobile (matches Tailwind's md breakpoint)
+const isMobile = () => typeof window !== 'undefined' && window.innerWidth < 768;
+
+export function useAppTour({ onComplete, onCancel, onOpenMobileMenu, onCloseMobileMenu }: UseAppTourOptions = {}) {
   const tour = useMemo(() => {
+    const mobile = isMobile();
+
     const tourInstance = new Shepherd.Tour({
-      useModalOverlay: true,
+      // On mobile, disable modal overlay since we show centered modals
+      // On desktop, use overlay to focus attention on attached elements
+      useModalOverlay: !mobile,
       defaultStepOptions: {
         classes: 'shepherd-theme-custom',
         scrollTo: { behavior: 'smooth', block: 'center' },
         cancelIcon: {
           enabled: true,
         },
+        // Help with positioning in complex layouts
+        popperOptions: {
+          modifiers: [
+            {
+              name: 'offset',
+              options: {
+                offset: [0, 12],
+              },
+            },
+            {
+              name: 'preventOverflow',
+              options: {
+                boundary: 'viewport',
+                padding: 16,
+              },
+            },
+          ],
+        },
       },
     });
+
+    // Helper to create step config
+    const createStep = (
+      id: string,
+      title: string,
+      text: string,
+      selector: string,
+      isFirst = false,
+      isLast = false
+    ) => {
+      const buttons: Array<{ text: string; classes: string; action: () => void }> = [];
+
+      if (!isFirst) {
+        buttons.push({
+          text: 'Back',
+          classes: 'shepherd-button-secondary',
+          action: () => { tourInstance.back(); },
+        });
+      }
+
+      buttons.push({
+        text: isLast ? 'Get Started!' : 'Next',
+        classes: 'shepherd-button-primary',
+        action: () => {
+          if (isLast) {
+            tourInstance.complete();
+          } else {
+            tourInstance.next();
+          }
+        },
+      });
+
+      return {
+        id,
+        title,
+        text,
+        // On desktop, attach to elements. On mobile, show centered modals
+        ...(!mobile && selector ? {
+          attachTo: {
+            element: selector,
+            on: 'right' as const,
+          },
+        } : {}),
+        buttons,
+      };
+    };
 
     // Step 1: Dashboard overview - centered modal, no attachment
     tourInstance.addStep({
       id: 'dashboard',
-      title: 'Your Dashboard',
-      text: 'This is your home base. Here you can see your test readiness, weekly goals, key stats, and track your progress towards passing the exam.',
+      title: 'Welcome to Open Ham Prep!',
+      text: 'This is your dashboard where you track progress and access all study features.',
+      classes: 'shepherd-theme-custom shepherd-mobile-welcome',
       buttons: [
         {
           text: 'Next',
           classes: 'shepherd-button-primary',
-          action: tourInstance.next,
+          action: () => {
+            // On mobile, open the sidebar menu before showing sidebar steps
+            if (isMobile() && onOpenMobileMenu) {
+              onOpenMobileMenu();
+              // Give the sheet time to open and render
+              setTimeout(() => {
+                tourInstance.next();
+              }, 350);
+            } else {
+              tourInstance.next();
+            }
+          },
         },
       ],
     });
 
     // Step 2: License selector
-    tourInstance.addStep({
-      id: 'license-selector',
-      title: 'License Selector',
-      text: 'Studying for a different license? Click here to switch between Technician, General, and Extra at any time.',
-      attachTo: {
-        element: '[data-tour="license-selector"]',
-        on: 'right',
-      },
-      buttons: [
-        {
-          text: 'Back',
-          classes: 'shepherd-button-secondary',
-          action: tourInstance.back,
-        },
-        {
-          text: 'Next',
-          classes: 'shepherd-button-primary',
-          action: tourInstance.next,
-        },
-      ],
-    });
+    tourInstance.addStep(createStep(
+      'license-selector',
+      'License Selector',
+      'Studying for a different license? Click here to switch between Technician, General, and Extra at any time.',
+      '[data-tour="license-selector"]'
+    ));
 
     // Step 3: Practice Test
-    tourInstance.addStep({
-      id: 'practice-test',
-      title: 'Practice Tests',
-      text: 'Take full-length practice exams just like the real test. Track your progress and see if you\'re ready to pass!',
-      attachTo: {
-        element: '[data-tour="practice-test"]',
-        on: 'right',
-      },
-      buttons: [
-        {
-          text: 'Back',
-          classes: 'shepherd-button-secondary',
-          action: tourInstance.back,
-        },
-        {
-          text: 'Next',
-          classes: 'shepherd-button-primary',
-          action: tourInstance.next,
-        },
-      ],
-    });
+    tourInstance.addStep(createStep(
+      'practice-test',
+      'Practice Tests',
+      'Take full-length practice exams just like the real test. Track your progress and see if you\'re ready to pass!',
+      '[data-tour="practice-test"]'
+    ));
 
     // Step 4: Random Practice
-    tourInstance.addStep({
-      id: 'random-practice',
-      title: 'Random Practice',
-      text: 'Quick study sessions with random questions. Perfect for daily practice and building streaks!',
-      attachTo: {
-        element: '[data-tour="random-practice"]',
-        on: 'right',
-      },
-      buttons: [
-        {
-          text: 'Back',
-          classes: 'shepherd-button-secondary',
-          action: tourInstance.back,
-        },
-        {
-          text: 'Next',
-          classes: 'shepherd-button-primary',
-          action: tourInstance.next,
-        },
-      ],
-    });
+    tourInstance.addStep(createStep(
+      'random-practice',
+      'Random Practice',
+      'Quick study sessions with random questions. Perfect for daily practice and building streaks!',
+      '[data-tour="random-practice"]'
+    ));
 
     // Step 5: Study by Topic
-    tourInstance.addStep({
-      id: 'study-by-topic',
-      title: 'Study by Topic',
-      text: 'Focus on specific subelements to master each section of the exam. Great for targeted learning!',
-      attachTo: {
-        element: '[data-tour="subelement-practice"]',
-        on: 'right',
-      },
-      buttons: [
-        {
-          text: 'Back',
-          classes: 'shepherd-button-secondary',
-          action: tourInstance.back,
-        },
-        {
-          text: 'Next',
-          classes: 'shepherd-button-primary',
-          action: tourInstance.next,
-        },
-      ],
-    });
+    tourInstance.addStep(createStep(
+      'study-by-topic',
+      'Study by Topic',
+      'Focus on specific subelements to master each section of the exam. Great for targeted learning!',
+      '[data-tour="subelement-practice"]'
+    ));
 
     // Step 6: Weak Areas
-    tourInstance.addStep({
-      id: 'weak-areas',
-      title: 'Weak Areas',
-      text: 'We track which questions you miss most often. Review them here to turn weaknesses into strengths!',
-      attachTo: {
-        element: '[data-tour="weak-questions"]',
-        on: 'right',
-      },
-      buttons: [
-        {
-          text: 'Back',
-          classes: 'shepherd-button-secondary',
-          action: tourInstance.back,
-        },
-        {
-          text: 'Next',
-          classes: 'shepherd-button-primary',
-          action: tourInstance.next,
-        },
-      ],
-    });
+    tourInstance.addStep(createStep(
+      'weak-areas',
+      'Weak Areas',
+      'We track which questions you miss most often. Review them here to turn weaknesses into strengths!',
+      '[data-tour="weak-questions"]'
+    ));
 
     // Step 7: Glossary
-    tourInstance.addStep({
-      id: 'glossary',
-      title: 'Glossary & Flashcards',
-      text: 'Learn key terms and definitions with our glossary. Use flashcards for effective memorization!',
-      attachTo: {
-        element: '[data-tour="glossary"]',
-        on: 'right',
-      },
-      buttons: [
-        {
-          text: 'Back',
-          classes: 'shepherd-button-secondary',
-          action: tourInstance.back,
-        },
-        {
-          text: 'Next',
-          classes: 'shepherd-button-primary',
-          action: tourInstance.next,
-        },
-      ],
-    });
+    tourInstance.addStep(createStep(
+      'glossary',
+      'Glossary & Flashcards',
+      'Learn key terms and definitions with our glossary. Use flashcards for effective memorization!',
+      '[data-tour="glossary"]'
+    ));
 
     // Step 8: Find Test Site
-    tourInstance.addStep({
-      id: 'find-test-site',
-      title: 'Find a Test Site',
-      text: 'Ready to take the real exam? Find testing sessions near you and set your target exam date!',
-      attachTo: {
-        element: '[data-tour="find-test-site"]',
-        on: 'right',
-      },
-      buttons: [
-        {
-          text: 'Back',
-          classes: 'shepherd-button-secondary',
-          action: tourInstance.back,
-        },
-        {
-          text: 'Next',
-          classes: 'shepherd-button-primary',
-          action: tourInstance.next,
-        },
-      ],
-    });
+    tourInstance.addStep(createStep(
+      'find-test-site',
+      'Find a Test Site',
+      'Ready to take the real exam? Find testing sessions near you and set your target exam date!',
+      '[data-tour="find-test-site"]'
+    ));
 
     // Step 9: Forum / Community
-    tourInstance.addStep({
-      id: 'forum',
-      title: 'Join Our Community',
-      text: 'Have questions? Want to share tips? Join our forum to connect with other ham radio enthusiasts, get help, and share your knowledge!',
-      attachTo: {
-        element: '[data-tour="forum"]',
-        on: 'right',
-      },
-      buttons: [
-        {
-          text: 'Back',
-          classes: 'shepherd-button-secondary',
-          action: tourInstance.back,
-        },
-        {
-          text: 'Next',
-          classes: 'shepherd-button-primary',
-          action: tourInstance.next,
-        },
-      ],
-    });
+    tourInstance.addStep(createStep(
+      'forum',
+      'Join Our Community',
+      'Have questions? Want to share tips? Join our forum to connect with other ham radio enthusiasts, get help, and share your knowledge!',
+      '[data-tour="forum"]'
+    ));
 
-    // Step 10: Encouraging completion message
+    // Step 10: Encouraging completion message - close sidebar first on mobile
     tourInstance.addStep({
       id: 'complete',
-      title: "You're All Set! 🎉",
+      title: "You're All Set!",
       text: `
         <div style="text-align: center;">
-          <p style="font-size: 1.1em; margin-bottom: 12px;">
-            You're ready to start your journey to becoming a licensed amateur radio operator!
+          <p style="margin-bottom: 8px;">
+            You're ready to start your ham radio journey!
           </p>
-          <p style="color: var(--muted-foreground); margin-bottom: 8px;">
-            Remember: Consistent practice is the key to success.
+          <p style="color: var(--muted-foreground); font-size: 0.9em;">
+            Start with a practice test to see where you stand.
           </p>
-          <p style="color: var(--muted-foreground);">
-            We recommend starting with a practice test to see where you stand, then focus on your weak areas.
-          </p>
-          <p style="margin-top: 16px; font-weight: 600; color: var(--primary);">
+          <p style="margin-top: 12px; font-weight: 600; color: var(--primary);">
             73 and good luck! 📻
           </p>
         </div>
       `,
+      classes: 'shepherd-theme-custom shepherd-mobile-welcome',
+      beforeShowPromise: () => {
+        return new Promise<void>((resolve) => {
+          // Close mobile menu before showing final step
+          if (isMobile() && onCloseMobileMenu) {
+            onCloseMobileMenu();
+            setTimeout(resolve, 300);
+          } else {
+            resolve();
+          }
+        });
+      },
       buttons: [
         {
           text: 'Get Started!',
           classes: 'shepherd-button-primary',
-          action: tourInstance.complete,
+          action: () => { tourInstance.complete(); },
         },
       ],
     });
 
     return tourInstance;
-  }, []);
+  }, [onOpenMobileMenu, onCloseMobileMenu]);
 
   // Set up event handlers
   useEffect(() => {

--- a/src/index.css
+++ b/src/index.css
@@ -168,11 +168,26 @@
 
 /* Shepherd.js Custom Theme */
 .shepherd-element {
-  z-index: 9999;
+  z-index: 99999 !important;
+  pointer-events: auto !important;
+  isolation: isolate;
 }
 
 .shepherd-modal-overlay-container {
-  z-index: 9998;
+  z-index: 99998 !important;
+}
+
+/* Ensure all Shepherd content and buttons are clickable */
+.shepherd-element .shepherd-content,
+.shepherd-element .shepherd-footer,
+.shepherd-element .shepherd-button {
+  pointer-events: auto !important;
+}
+
+.shepherd-element .shepherd-button {
+  position: relative;
+  z-index: 1;
+  cursor: pointer !important;
 }
 
 /* Reset all Shepherd default styles */
@@ -295,3 +310,52 @@
 .shepherd-modal-overlay-container.shepherd-modal-is-visible {
   opacity: 0.6;
 }
+
+/* Mobile-specific Shepherd styles */
+@media (max-width: 767px) {
+  .shepherd-element.shepherd-theme-custom {
+    max-width: calc(100vw - 3rem);
+    width: calc(100vw - 3rem);
+    margin: 0 auto;
+    /* Add stronger shadow on mobile since there's no overlay */
+    box-shadow: 0 -4px 30px -5px rgba(0, 0, 0, 0.4), 0 10px 40px -10px rgba(0, 0, 0, 0.3) !important;
+  }
+
+  .shepherd-element.shepherd-theme-custom .shepherd-header {
+    padding: 0.625rem 0.625rem 0.375rem 0.625rem;
+  }
+
+  .shepherd-element.shepherd-theme-custom .shepherd-title {
+    font-size: 0.9375rem;
+  }
+
+  .shepherd-element.shepherd-theme-custom .shepherd-text {
+    padding: 0.25rem 0.625rem 0.625rem 0.625rem;
+    font-size: 0.8125rem;
+    line-height: 1.4;
+  }
+
+  .shepherd-element.shepherd-theme-custom .shepherd-footer {
+    padding: 0 0.625rem 0.625rem 0.625rem;
+  }
+
+  .shepherd-element.shepherd-theme-custom .shepherd-button {
+    font-size: 0.75rem;
+    padding: 0.35rem 0.625rem;
+  }
+
+  .shepherd-element.shepherd-theme-custom .shepherd-cancel-icon {
+    font-size: 1.25rem;
+  }
+
+  /* Mobile: center the modal at the bottom of the screen */
+  .shepherd-element.shepherd-theme-custom {
+    position: fixed !important;
+    bottom: 1rem !important;
+    left: 50% !important;
+    right: auto !important;
+    top: auto !important;
+    transform: translateX(-50%) !important;
+  }
+}
+

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -59,6 +59,10 @@ export default function Dashboard() {
   const [showNavigationWarning, setShowNavigationWarning] = useState(false);
   const [showGoalsModal, setShowGoalsModal] = useState(false);
 
+  // Mobile menu state for sidebar (controlled by tour)
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [isTourActive, setIsTourActive] = useState(false);
+
   // Onboarding
   const {
     showOnboarding,
@@ -69,8 +73,18 @@ export default function Dashboard() {
   const [showWelcomeModal, setShowWelcomeModal] = useState(false);
 
   const { startTour } = useAppTour({
-    onComplete: completeOnboarding,
-    onCancel: skipOnboarding,
+    onComplete: () => {
+      setIsTourActive(false);
+      setMobileMenuOpen(false);
+      completeOnboarding();
+    },
+    onCancel: () => {
+      setIsTourActive(false);
+      setMobileMenuOpen(false);
+      skipOnboarding();
+    },
+    onOpenMobileMenu: () => setMobileMenuOpen(true),
+    onCloseMobileMenu: () => setMobileMenuOpen(false),
   });
 
   // Show welcome modal when onboarding should start
@@ -90,6 +104,7 @@ export default function Dashboard() {
     setShowOnboarding(false);
     // Start the tour after a short delay to let the modal close
     setTimeout(() => {
+      setIsTourActive(true);
       startTour();
     }, 300);
   };
@@ -766,7 +781,7 @@ export default function Dashboard() {
         onSkip={handleWelcomeSkip}
       />
 
-      <AppLayout currentView={currentView} onViewChange={handleViewChange} selectedTest={selectedTest} onTestChange={setSelectedTest}>
+      <AppLayout currentView={currentView} onViewChange={handleViewChange} selectedTest={selectedTest} onTestChange={setSelectedTest} mobileMenuOpen={mobileMenuOpen} onMobileMenuChange={setMobileMenuOpen} isTourActive={isTourActive}>
         {renderContent()}
       </AppLayout>
     </>;


### PR DESCRIPTION
## Summary
- Add welcome modal for new users to select their license class (Technician, General, Extra)
- Implement guided tour using Shepherd.js that walks users through key app features
- Add onboarding state management with localStorage persistence
- Create license select modal accessible from sidebar for changing license anytime
- Add mobile-responsive tour with centered modals and automatic sidebar control

## Features
- **Welcome Modal**: First-time users see a modal to choose their license class with exam details (question count, passing score)
- **Guided Tour**: 10-step tour covering Dashboard, License Selector, Practice Tests, Random Practice, Study by Topic, Weak Areas, Glossary, Find Test Site, Forum, and completion
- **Mobile Support**: Tour opens/closes sidebar automatically, shows centered modals on small screens
- **Skip Option**: Users can skip the tour at any time; tour won't show again
- **Persistent State**: Onboarding completion stored in localStorage

## Test plan
- [ ] Sign up as new user and verify welcome modal appears
- [ ] Select a license and confirm tour starts
- [ ] Complete tour and verify it doesn't show again on refresh
- [ ] Test "Skip tour" button works correctly
- [ ] Run `resetOnboarding()` in console to restart the tour
- [ ] Verify tour works on both mobile and desktop viewports
- [ ] Verify license modal can be opened from sidebar after onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)