### PR TITLE
Fix Vite envPrefix to expose VITE_ environment variables

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,8 +12,8 @@ export default defineConfig(({ mode }) => ({
   build: {
     target: "esnext", // Target modern browsers to avoid legacy polyfills
   },
-  // Expose NEXT_PUBLIC_ env vars (auto-set by Supabase Vercel Integration)
-  envPrefix: ["NEXT_PUBLIC_"],
+  // Expose env vars: NEXT_PUBLIC_ (Supabase) and VITE_ (PostHog, Pendo)
+  envPrefix: ["NEXT_PUBLIC_", "VITE_"],
   plugins: [react(), mode === "development" && componentTagger()].filter(Boolean),
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Fixed Vite config to include `VITE_` prefix in `envPrefix` array alongside `NEXT_PUBLIC_`
- This allows PostHog and Pendo to read their API keys (`VITE_POSTHOG_KEY`, `VITE_PENDO_API_KEY`) from environment variables
- Without this fix, both analytics services silently failed to initialize

## Test plan
- [ ] Verify dev server starts without errors
- [ ] Add PostHog API key to `.env` and confirm events are captured in PostHog dashboard
- [ ] Add Pendo API key to `.env` and confirm Pendo initializes for authenticated users
- [ ] Run `npm run build` to ensure production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)