### PR TITLE
Fix statuspage embed URL and add utility module with tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,6 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
-    <script src="https://openhamprep1.statuspage.io/embed/script.js"></script>
+    <script src="https://openhamprep.statuspage.io/embed/script.js"></script>
   </body>
 </html>

--- a/src/lib/statuspage.test.ts
+++ b/src/lib/statuspage.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import {
+  STATUSPAGE_URL,
+  STATUSPAGE_EMBED_SCRIPT,
+  isStatusPageAvailable,
+  openStatusWidget,
+  getStatusPageUrl,
+} from './statuspage';
+
+describe('statuspage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Clean up any existing statusEmbedTest
+    delete (window as Window).statusEmbedTest;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (window as Window).statusEmbedTest;
+  });
+
+  describe('constants', () => {
+    it('should have correct STATUSPAGE_URL', () => {
+      expect(STATUSPAGE_URL).toBe('https://openhamprep.statuspage.io');
+    });
+
+    it('should have correct STATUSPAGE_EMBED_SCRIPT', () => {
+      expect(STATUSPAGE_EMBED_SCRIPT).toBe('https://openhamprep.statuspage.io/embed/script.js');
+    });
+
+    it('should not contain old incorrect URL', () => {
+      expect(STATUSPAGE_URL).not.toContain('openhamprep1');
+      expect(STATUSPAGE_EMBED_SCRIPT).not.toContain('openhamprep1');
+    });
+  });
+
+  describe('isStatusPageAvailable', () => {
+    it('should return false when statusEmbedTest is not defined', () => {
+      expect(isStatusPageAvailable()).toBe(false);
+    });
+
+    it('should return false when statusEmbedTest is not a function', () => {
+      (window as Window & { statusEmbedTest?: unknown }).statusEmbedTest = 'not a function';
+      expect(isStatusPageAvailable()).toBe(false);
+    });
+
+    it('should return true when statusEmbedTest is a function', () => {
+      window.statusEmbedTest = vi.fn();
+      expect(isStatusPageAvailable()).toBe(true);
+    });
+  });
+
+  describe('openStatusWidget', () => {
+    it('should return false when widget is not available', () => {
+      const result = openStatusWidget();
+      expect(result).toBe(false);
+    });
+
+    it('should call statusEmbedTest and return true when available', () => {
+      const mockStatusEmbedTest = vi.fn();
+      window.statusEmbedTest = mockStatusEmbedTest;
+
+      const result = openStatusWidget();
+
+      expect(result).toBe(true);
+      expect(mockStatusEmbedTest).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not throw when widget is not available', () => {
+      expect(() => openStatusWidget()).not.toThrow();
+    });
+  });
+
+  describe('getStatusPageUrl', () => {
+    it('should return the correct status page URL', () => {
+      expect(getStatusPageUrl()).toBe('https://openhamprep.statuspage.io');
+    });
+  });
+});
+
+describe('index.html statuspage script', () => {
+  const indexHtmlPath = resolve(__dirname, '../../index.html');
+  let indexHtmlContent: string;
+
+  beforeEach(() => {
+    indexHtmlContent = readFileSync(indexHtmlPath, 'utf-8');
+  });
+
+  it('should contain the statuspage embed script', () => {
+    expect(indexHtmlContent).toContain('statuspage.io/embed/script.js');
+  });
+
+  it('should use correct statuspage subdomain (openhamprep, not openhamprep1)', () => {
+    expect(indexHtmlContent).toContain('https://openhamprep.statuspage.io/embed/script.js');
+    expect(indexHtmlContent).not.toContain('openhamprep1.statuspage.io');
+  });
+
+  it('should have script tag matching STATUSPAGE_EMBED_SCRIPT constant', () => {
+    expect(indexHtmlContent).toContain(STATUSPAGE_EMBED_SCRIPT);
+  });
+});

--- a/src/lib/statuspage.ts
+++ b/src/lib/statuspage.ts
@@ -1,0 +1,41 @@
+/**
+ * Statuspage integration utilities
+ *
+ * This module provides a typed interface to the Statuspage.io embed widget.
+ * The embed script is loaded in index.html and exposes window.statusEmbedTest.
+ */
+
+export const STATUSPAGE_URL = 'https://openhamprep.statuspage.io';
+export const STATUSPAGE_EMBED_SCRIPT = `${STATUSPAGE_URL}/embed/script.js`;
+
+declare global {
+  interface Window {
+    statusEmbedTest?: () => void;
+  }
+}
+
+/**
+ * Check if the Statuspage widget is available
+ */
+export function isStatusPageAvailable(): boolean {
+  return typeof window !== 'undefined' && typeof window.statusEmbedTest === 'function';
+}
+
+/**
+ * Open the Statuspage floating widget
+ * @returns true if the widget was opened, false if not available
+ */
+export function openStatusWidget(): boolean {
+  if (isStatusPageAvailable()) {
+    window.statusEmbedTest!();
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Get the Statuspage URL for the status page
+ */
+export function getStatusPageUrl(): string {
+  return STATUSPAGE_URL;
+}

--- a/website/about.html
+++ b/website/about.html
@@ -304,6 +304,6 @@
       closeIcon.classList.toggle('hidden');
     });
   </script>
-  <script src="https://openhamprep1.statuspage.io/embed/script.js"></script>
+  <script src="https://openhamprep.statuspage.io/embed/script.js"></script>
 </body>
 </html>

--- a/website/faq.html
+++ b/website/faq.html
@@ -167,6 +167,6 @@
       });
     });
   </script>
-  <script src="https://openhamprep1.statuspage.io/embed/script.js"></script>
+  <script src="https://openhamprep.statuspage.io/embed/script.js"></script>
 </body>
 </html>

--- a/website/features.html
+++ b/website/features.html
@@ -195,6 +195,6 @@
       closeIcon.classList.toggle('hidden');
     });
   </script>
-  <script src="https://openhamprep1.statuspage.io/embed/script.js"></script>
+  <script src="https://openhamprep.statuspage.io/embed/script.js"></script>
 </body>
 </html>

--- a/website/index.html
+++ b/website/index.html
@@ -274,6 +274,6 @@
       closeIcon.classList.toggle('hidden');
     });
   </script>
-  <script src="https://openhamprep1.statuspage.io/embed/script.js"></script>
+  <script src="https://openhamprep.statuspage.io/embed/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Fixed incorrect statuspage subdomain (`openhamprep1` → `openhamprep`) in all 5 HTML files
- Added `src/lib/statuspage.ts` utility module with typed interface to the statuspage widget
- Added `src/lib/statuspage.test.ts` with 13 tests including index.html validation to prevent regression

## Test plan
- [x] All 943 tests pass including 13 new statuspage tests
- [ ] Verify `statusEmbedTest()` opens the floating widget in browser console after deployment
- [ ] Confirm widget appears on both app and marketing website

🤖 Generated with [Claude Code](https://claude.com/claude-code)