### PR TITLE
fix: Redirect to auth page after logout

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -72,8 +72,9 @@ export function AppLayout({ children, currentView, onViewChange, selectedTest, o
     : [];
 
   const handleSignOut = async () => {
-    await signOut();
+    // Navigate first to ensure we redirect before state changes trigger re-renders
     navigate('/auth');
+    await signOut();
   };
 
   const handleProfileUpdate = () => {

--- a/src/pages/Dashboard.test.tsx
+++ b/src/pages/Dashboard.test.tsx
@@ -227,7 +227,7 @@ describe('Dashboard', () => {
   });
 
   describe('Authentication Redirect', () => {
-    it('redirects to home when user is not authenticated', async () => {
+    it('redirects to auth page when user is not authenticated', async () => {
       // Override useAuth mock for this test
       mockAuthHook.mockReturnValueOnce({
         user: null,
@@ -237,7 +237,7 @@ describe('Dashboard', () => {
       renderDashboard();
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/');
+        expect(mockNavigate).toHaveBeenCalledWith('/auth');
       });
     });
   });

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -135,7 +135,7 @@ export default function Dashboard() {
   };
   useEffect(() => {
     if (!authLoading && !user) {
-      navigate('/');
+      navigate('/auth');
     }
   }, [user, authLoading, navigate]);
   const {


### PR DESCRIPTION
## Summary
- Fix bug where users stayed on current page after signing out, causing confusion
- Navigate to `/auth` before calling `signOut()` to ensure redirect happens before state changes trigger re-renders
- Change Dashboard's unauthenticated redirect from `/` to `/auth` for consistency

## Test plan
- [ ] Sign out from the dashboard - should redirect to auth page
- [ ] Sign out from any other authenticated page - should redirect to auth page
- [ ] Try accessing `/dashboard` when not authenticated - should redirect to auth page
- [ ] Run `npm run test:run` - all 1028 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)