### PR TITLE
chore: Clean up debug console statements for production

### DIFF
--- a/src/components/ProfileModal.tsx
+++ b/src/components/ProfileModal.tsx
@@ -160,8 +160,6 @@ export function ProfileModal({
           // Don't block local deletion if Discourse deletion fails
           // The user might not have a Discourse account, or the forum might be unavailable
           console.error('Discourse deletion error:', discourseResponse.error);
-        } else if (discourseResponse.data?.discourseAccountFound) {
-          console.log('Discourse account deleted:', discourseResponse.data.discourseUsername);
         }
       } catch (discourseError) {
         // Log but don't block - Discourse deletion is best-effort

--- a/src/components/admin/AdminExamSessions.tsx
+++ b/src/components/admin/AdminExamSessions.tsx
@@ -97,7 +97,7 @@ export const AdminExamSessions = () => {
       refetchLastUpdated();
     } catch (err) {
       toast.error('Geocoding failed');
-      console.error(err);
+      console.error('Geocoding exam sessions failed:', err);
     } finally {
       setGeocoding(false);
       setGeocodeProgress(null);

--- a/src/hooks/useBookmarks.ts
+++ b/src/hooks/useBookmarks.ts
@@ -49,7 +49,7 @@ export function useBookmarks() {
     },
     onError: (error) => {
       toast.error('Failed to bookmark question');
-      console.error(error);
+      console.error('Failed to add bookmark:', error);
     },
   });
 
@@ -73,7 +73,7 @@ export function useBookmarks() {
     },
     onError: (error) => {
       toast.error('Failed to remove bookmark');
-      console.error(error);
+      console.error('Failed to remove bookmark:', error);
     },
   });
 
@@ -95,7 +95,7 @@ export function useBookmarks() {
     },
     onError: (error) => {
       toast.error('Failed to update note');
-      console.error(error);
+      console.error('Failed to update bookmark note:', error);
     },
   });
 

--- a/src/hooks/useOAuthConsent.ts
+++ b/src/hooks/useOAuthConsent.ts
@@ -117,15 +117,11 @@ export function useOAuthConsent(): UseOAuthConsentReturn {
         throw new Error('Failed to fetch authorization details');
       }
 
-      // Log the full response to debug field names
-      console.log(LOG_PREFIX, 'Authorization details received:', JSON.stringify(authDetails, null, 2));
-
       // Check if Supabase returned a redirect_url with authorization code already included
       // This happens when consent was already granted via Supabase's internal consent management.
       // Per Supabase docs: "If the response includes a redirect_uri, it means consent was already given"
       const preApprovedRedirectUrl = authDetails.redirect_url || authDetails.redirect_uri;
       if (preApprovedRedirectUrl && preApprovedRedirectUrl.includes('code=')) {
-        console.log(LOG_PREFIX, 'Consent already granted, redirecting to:', preApprovedRedirectUrl);
         setIsAutoApproving(true);
         window.location.href = preApprovedRedirectUrl;
         return;

--- a/src/hooks/useOnboarding.test.tsx
+++ b/src/hooks/useOnboarding.test.tsx
@@ -501,7 +501,7 @@ describe('useOnboarding', () => {
         await window.resetOnboarding();
       }
 
-      expect(consoleLogSpy).toHaveBeenCalledWith('❌ No user logged in. Please log in first.');
+      expect(consoleLogSpy).toHaveBeenCalledWith('No user logged in. Please log in first.');
 
       consoleLogSpy.mockRestore();
 
@@ -612,7 +612,7 @@ describe('useOnboarding', () => {
       // Call the global function
       await window.resetOnboarding();
 
-      expect(consoleLogSpy).toHaveBeenCalledWith('🎉 Onboarding reset! Refreshing page...');
+      expect(consoleLogSpy).toHaveBeenCalledWith('Onboarding reset! Refreshing page...');
       expect(reloadMock).toHaveBeenCalled();
 
       consoleLogSpy.mockRestore();

--- a/src/hooks/useOnboarding.tsx
+++ b/src/hooks/useOnboarding.tsx
@@ -97,11 +97,13 @@ export function useOnboarding() {
     await updateOnboardingStatus(false);
   }, [updateOnboardingStatus]);
 
-  // Register global console command for testing
+  // Register global console command for testing (dev only)
   useEffect(() => {
+    if (!import.meta.env.DEV) return;
+
     window.resetOnboarding = async () => {
       if (!user) {
-        console.log('❌ No user logged in. Please log in first.');
+        console.log('No user logged in. Please log in first.');
         return;
       }
 
@@ -114,7 +116,7 @@ export function useOnboarding() {
         if (error) {
           console.error('Error resetting onboarding:', error);
         } else {
-          console.log('🎉 Onboarding reset! Refreshing page...');
+          console.log('Onboarding reset! Refreshing page...');
           window.location.reload();
         }
       } catch (err) {
@@ -122,10 +124,7 @@ export function useOnboarding() {
       }
     };
 
-    // Log availability in development
-    if (import.meta.env.DEV) {
-      console.log('💡 Tip: Run resetOnboarding() in console to restart the onboarding tour');
-    }
+    console.log('Tip: Run resetOnboarding() in console to restart the onboarding tour');
 
     return () => {
       delete window.resetOnboarding;

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -39,10 +39,6 @@ export default function Auth() {
   const searchParams = new URLSearchParams(location.search);
   const returnTo = searchParams.get('returnTo');
 
-  // Debug logging for OAuth flow
-  console.log('[Auth] Current URL:', location.pathname + location.search + location.hash);
-  console.log('[Auth] returnTo:', returnTo);
-
   // Check for email verification success in URL
   useEffect(() => {
     const hashParams = new URLSearchParams(location.hash.substring(1));
@@ -67,7 +63,6 @@ export default function Auth() {
     if (user) {
       // If there's a returnTo URL (e.g., from OAuth consent flow), redirect there
       // Otherwise, go to home page
-      console.log('[Auth] User detected, redirecting to:', returnTo || '/');
       navigate(returnTo || '/');
     }
   }, [user, navigate, returnTo]);


### PR DESCRIPTION
## Summary

- Remove debug `console.log` statements that were cluttering the production console
- Make dev-only utilities (like `resetOnboarding()`) properly gated behind `import.meta.env.DEV`
- Improve error message context for legitimate `console.error` statements

## Changes

**Removed debug statements:**
- `Auth.tsx`: Removed OAuth flow debugging logs (3 statements)
- `useOAuthConsent.ts`: Removed authorization details debugging (2 statements)
- `ProfileModal.tsx`: Removed success confirmation log (1 statement)
- `useOnboarding.tsx`: Made `resetOnboarding()` console command dev-only, removed emojis

**Improved error messages:**
- `useBookmarks.ts`: Added context to 3 generic error logs
- `AdminExamSessions.tsx`: Added context to geocoding error

## Test plan

- [x] All 1111 tests pass
- [x] TypeScript compiles without errors
- [x] ESLint passes (only pre-existing warnings)
- [ ] Verify production console is clean after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)