### PR TITLE
fix: use correct wildcard character for Supabase like queries

### DIFF
--- a/src/components/admin/AdminQuestions.tsx
+++ b/src/components/admin/AdminQuestions.tsx
@@ -103,7 +103,7 @@ export function AdminQuestions({
         error
       } = await supabase.from('questions')
         .select('id, question, options, correct_answer, subelement, question_group, links, explanation, edit_history, figure_url')
-        .like('id', `${prefix}%`)
+        .ilike('id', `${prefix}*`)
         .order('id', { ascending: true });
       if (error) throw error;
       return data.map(q => ({

--- a/src/components/admin/AdminStats.tsx
+++ b/src/components/admin/AdminStats.tsx
@@ -40,7 +40,7 @@ export function AdminStats({ testType, onAddLinkToQuestion }: AdminStatsProps) {
       const { data, error } = await supabase
         .from('questions')
         .select('id, question, subelement, question_group, links, explanation')
-        .like('id', `${prefix}%`)
+        .ilike('id', `${prefix}*`)
         .order('id');
       
       if (error) throw error;
@@ -59,7 +59,7 @@ export function AdminStats({ testType, onAddLinkToQuestion }: AdminStatsProps) {
       const { data, error } = await supabase
         .from('question_attempts')
         .select('question_id, is_correct, user_id, attempted_at')
-        .like('question_id', `${prefix}%`)
+        .ilike('question_id', `${prefix}*`)
         .order('attempted_at', { ascending: true });
       
       if (error) throw error;

--- a/src/hooks/useExamSessions.ts
+++ b/src/hooks/useExamSessions.ts
@@ -72,7 +72,7 @@ export const useExamSessions = (filters?: {
       // Filter by zip code prefix (first 3 digits) on server
       if (filters?.zip && filters.zip.length >= 3) {
         const zipPrefix = filters.zip.substring(0, 3);
-        query = query.like('zip', `${zipPrefix}%`);
+        query = query.ilike('zip', `${zipPrefix}*`);
       }
       // Filter by walk-ins allowed
       if (filters?.walkInsOnly) {


### PR DESCRIPTION
## Summary
- Fixed 400 Bad Request errors in admin questions list by using `*` instead of `%` as the wildcard character in Supabase `.ilike()` queries
- PostgREST uses `*` for pattern matching, not the SQL standard `%`
- Also fixed exam session zip code filtering which had the same issue

## Test plan
- [ ] Load admin questions page for Technician, General, and Extra - should no longer return 400 errors
- [ ] Test exam session search with zip code filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)