### PR TITLE
fix: remove duplicate scroll container on topic pages

### DIFF
--- a/src/components/TopicDetailPage.tsx
+++ b/src/components/TopicDetailPage.tsx
@@ -30,7 +30,7 @@ export function TopicDetailPage({ slug, onBack }: TopicDetailPageProps) {
   // Loading state
   if (topicLoading) {
     return (
-      <div className="flex-1 overflow-y-auto py-8 px-4 md:px-8">
+      <div className="flex-1 py-8 px-4 md:px-8">
         <div className="max-w-7xl mx-auto">
           {/* Header skeleton */}
           <div className="mb-8">
@@ -87,7 +87,7 @@ export function TopicDetailPage({ slug, onBack }: TopicDetailPageProps) {
   const displayContent = content || `# ${topic.title}\n\n${topic.description || "Content coming soon..."}\n\nThis topic is still being developed. Check back later for the full article.`;
 
   return (
-    <div className="flex-1 overflow-y-auto">
+    <div className="flex-1">
       {/* Header */}
       <motion.div
         initial={{ opacity: 0, y: -10 }}


### PR DESCRIPTION
## Summary
- Fixes double scroll bar issue on topic pages
- Removes `overflow-y-auto` from TopicDetailPage component (both loading state and main content)
- Page now uses single scroll context from AppLayout, preventing the entire app from scrolling when reaching end of topic content

## Test plan
- [ ] Navigate to a topic page
- [ ] Verify only one scroll bar appears
- [ ] Scroll to the bottom of the content
- [ ] Confirm scrolling stops at the end (doesn't continue to scroll the app)
- [ ] Verify sticky sidebars (Table of Contents, Questions panel) still work correctly
- [ ] Test on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)