### PR TITLE
fix: simplify migration function to use NULL as pending status

### DIFF
--- a/supabase/migrations/20260101000001_fix_discourse_sync_status_constraint.sql
+++ b/supabase/migrations/20260101000001_fix_discourse_sync_status_constraint.sql
@@ -1,0 +1,14 @@
+-- Fix discourse_sync_status constraint to match actual usage
+-- NULL is used as the pending state, so 'pending' is not needed
+
+-- Drop the old constraint
+ALTER TABLE public.questions
+  DROP CONSTRAINT IF EXISTS discourse_sync_status_check;
+
+-- Add updated constraint (NULL = pending, so we only need synced/error)
+ALTER TABLE public.questions
+  ADD CONSTRAINT discourse_sync_status_check
+  CHECK (discourse_sync_status IN ('synced', 'error') OR discourse_sync_status IS NULL);
+
+-- Update comment to clarify NULL = pending
+COMMENT ON COLUMN public.questions.discourse_sync_status IS 'Discourse sync status: synced, error, or null (pending/never synced)';


### PR DESCRIPTION
## Summary
- Use NULL as pending state instead of invalid 'external_id_pending' value
- Fixes database constraint violation (`discourse_sync_status_check` only allows: synced, error, pending, NULL)
- Add proper rate limit handling with retry logic (parses `wait_seconds` from Discourse 429 responses)
- Track progress using existing status values

## Changes
- **migrate-discourse-external-ids/index.ts**: Simplified to use NULL as pending, proper rate limit handling
- **migrate-discourse-external-ids.test.ts**: Updated tests to match new behavior

## Workflow
```
1. action="prepare"  → Sets all questions with forum_url to NULL (pending)
2. action="migrate"  → Processes pending questions, marks synced on success
3. action="dry-run"  → Shows counts by status
```

## Test plan
- [x] Unit tests pass
- [ ] Deploy function
- [ ] Run prepare action
- [ ] Run migrate action
- [ ] Verify questions marked as synced

🤖 Generated with [Claude Code](https://claude.ai/code)