### PR TITLE
feat: add PageContainer component for consistent layouts

### DIFF
--- a/src/components/BookmarkedQuestions.tsx
+++ b/src/components/BookmarkedQuestions.tsx
@@ -10,6 +10,7 @@ import { KeyboardShortcutsHelp } from "@/components/KeyboardShortcutsHelp";
 import { Bookmark, Loader2, Trash2, MessageSquare, ArrowLeft, ChevronLeft, ChevronRight, Dices } from "lucide-react";
 import { motion } from "framer-motion";
 import { TestType } from "@/types/navigation";
+import { PageContainer } from "@/components/ui/page-container";
 
 
 interface BookmarkedQuestionsProps {
@@ -103,17 +104,20 @@ export function BookmarkedQuestions({
   useKeyboardShortcuts(shortcuts, { enabled: !!selectedQuestion });
 
   if (isLoading) {
-    return <div className="flex-1 bg-background flex items-center justify-center">
+    return (
+      <PageContainer width="standard" mobileNavPadding className="flex items-center justify-center">
         <div className="text-center">
           <Loader2 className="w-8 h-8 animate-spin text-primary mx-auto mb-4" />
           <p className="text-muted-foreground">Loading bookmarks...</p>
         </div>
-      </div>;
+      </PageContainer>
+    );
   }
 
   if (selectedQuestion) {
-    return <div className="flex-1 bg-background py-8 px-4 pb-24 md:pb-8 overflow-y-auto">
-        <div className="max-w-3xl mx-auto mb-8">
+    return (
+      <PageContainer width="standard" mobileNavPadding>
+        <div className="mb-8">
           <div className="flex items-center justify-between mb-6">
             <Button variant="ghost" onClick={() => {
             setCurrentIndex(null);
@@ -156,7 +160,7 @@ export function BookmarkedQuestions({
       }} showResult={showResult} enableGlossaryHighlight onTopicClick={navigateToTopic} />
 
         {/* Navigation Actions */}
-        <div className="max-w-3xl mx-auto mt-8 flex justify-center gap-4">
+        <div className="mt-8 flex justify-center gap-4">
           <Button variant="outline" onClick={handlePrevQuestion} disabled={!canGoPrev} className="gap-2">
             <ChevronLeft className="w-4 h-4" />
             Previous
@@ -191,10 +195,11 @@ export function BookmarkedQuestions({
         }} className="text-center text-muted-foreground text-sm mt-4">
             Question {currentIndex + 1} of {bookmarkedQuestions.length}
           </motion.p>}
-      </div>;
+      </PageContainer>
+    );
   }
-  return <div className="flex-1 bg-background py-8 px-4 pb-24 md:pb-8 overflow-y-auto">
-      <div className="max-w-3xl mx-auto">
+  return (
+    <PageContainer width="standard" mobileNavPadding>
         {bookmarkedQuestions.length === 0 ? (
           <Card>
             <CardContent className="pt-6">
@@ -255,6 +260,6 @@ export function BookmarkedQuestions({
             })}
           </motion.div>
         )}
-      </div>
-    </div>;
+    </PageContainer>
+  );
 }

--- a/src/components/ExamSessionSearch.tsx
+++ b/src/components/ExamSessionSearch.tsx
@@ -15,6 +15,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { ExamSessionMap } from './ExamSessionMap';
 import { useExamSessions, useSaveTargetExam, useUserTargetExam, useRemoveTargetExam, type ExamSession } from '@/hooks/useExamSessions';
 import { useAuth } from '@/hooks/useAuth';
+import { PageContainer } from '@/components/ui/page-container';
 const US_STATES = ['AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'FL', 'GA', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ', 'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'RI', 'SC', 'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY'];
 
 // Map US states to timezone abbreviations (simplified - uses primary timezone for each state)
@@ -179,7 +180,8 @@ export const ExamSessionSearch = () => {
       year: 'numeric'
     });
   };
-  return <div className="flex-1 flex flex-col p-4 md:p-6 gap-4 min-h-0">
+  return (
+    <PageContainer width="wide" className="flex flex-col" contentClassName="flex flex-col gap-4 min-h-0">
       {/* Current Target Display */}
       {userTarget && <Card className="border-primary/50 bg-primary/5">
           <CardHeader className="pb-3">
@@ -453,5 +455,6 @@ export const ExamSessionSearch = () => {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>;
+    </PageContainer>
+  );
 };

--- a/src/components/Glossary.tsx
+++ b/src/components/Glossary.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
+import { PageContainer } from "@/components/ui/page-container";
 
 interface GlossaryProps {
   onStartFlashcards: () => void;
@@ -56,14 +57,14 @@ export function Glossary({ onStartFlashcards }: GlossaryProps) {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-64">
+      <PageContainer width="wide" className="flex items-center justify-center">
         <Loader2 className="w-8 h-8 animate-spin text-primary" />
-      </div>
+      </PageContainer>
     );
   }
 
   return (
-    <div className="flex flex-col h-full w-full max-w-4xl mx-auto py-8 md:py-12 px-4 md:px-8">
+    <PageContainer width="wide" className="flex flex-col h-full">
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-4">
         <div>
@@ -123,6 +124,6 @@ export function Glossary({ onStartFlashcards }: GlossaryProps) {
           </div>
         )}
       </ScrollArea>
-    </div>
+    </PageContainer>
   );
 }

--- a/src/components/GlossaryFlashcards.tsx
+++ b/src/components/GlossaryFlashcards.tsx
@@ -9,6 +9,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { cn } from "@/lib/utils";
 import { motion, AnimatePresence } from "framer-motion";
 import { usePostHog, ANALYTICS_EVENTS } from "@/hooks/usePostHog";
+import { PageContainer } from "@/components/ui/page-container";
 
 type FlashcardMode = 'term-to-definition' | 'definition-to-term';
 
@@ -124,16 +125,16 @@ export function GlossaryFlashcards({ onBack }: GlossaryFlashcardsProps) {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-64">
+      <PageContainer width="narrow" className="flex items-center justify-center">
         <Loader2 className="w-8 h-8 animate-spin text-primary" />
-      </div>
+      </PageContainer>
     );
   }
 
   // Start screen
   if (!hasStarted) {
     return (
-      <div className="flex flex-col h-full max-w-2xl mx-auto py-8 md:py-12 px-4 md:px-8">
+      <PageContainer width="narrow" className="flex flex-col h-full">
         <Button variant="ghost" onClick={onBack} className="self-start mb-6 gap-2">
           <ArrowLeft className="w-4 h-4" />
           Back to Glossary
@@ -149,7 +150,7 @@ export function GlossaryFlashcards({ onBack }: GlossaryFlashcardsProps) {
           <div className="w-full max-w-md mb-6">
             <h3 className="text-sm font-medium text-muted-foreground mb-3">Card Direction</h3>
             <div className="grid grid-cols-2 gap-3">
-              <Card 
+              <Card
                 className={cn(
                   "cursor-pointer transition-all hover:border-primary/50",
                   mode === 'term-to-definition' && "border-primary bg-primary/5"
@@ -161,7 +162,7 @@ export function GlossaryFlashcards({ onBack }: GlossaryFlashcardsProps) {
                 </CardContent>
               </Card>
 
-              <Card 
+              <Card
                 className={cn(
                   "cursor-pointer transition-all hover:border-primary/50",
                   mode === 'definition-to-term' && "border-primary bg-primary/5"
@@ -180,7 +181,7 @@ export function GlossaryFlashcards({ onBack }: GlossaryFlashcardsProps) {
             Start Studying
           </Button>
         </div>
-      </div>
+      </PageContainer>
     );
   }
 
@@ -192,7 +193,7 @@ export function GlossaryFlashcards({ onBack }: GlossaryFlashcardsProps) {
     const percentage = total > 0 ? Math.round((knownCount / total) * 100) : 0;
 
     return (
-      <div className="flex flex-col h-full max-w-2xl mx-auto py-8 md:py-12 px-4 md:px-8">
+      <PageContainer width="narrow" className="flex flex-col h-full">
         <Button variant="ghost" onClick={onBack} className="self-start mb-6 gap-2">
           <ArrowLeft className="w-4 h-4" />
           Back to Glossary
@@ -235,7 +236,7 @@ export function GlossaryFlashcards({ onBack }: GlossaryFlashcardsProps) {
             </Button>
           </div>
         </div>
-      </div>
+      </PageContainer>
     );
   }
 
@@ -246,7 +247,7 @@ export function GlossaryFlashcards({ onBack }: GlossaryFlashcardsProps) {
   const backLabel = mode === 'term-to-definition' ? 'Definition' : 'Term';
 
   return (
-    <div className="flex flex-col h-full max-w-2xl mx-auto py-8 md:py-12 px-4 md:px-8">
+    <PageContainer width="narrow" className="flex flex-col h-full">
       {/* Header */}
       <div className="flex items-center justify-between mb-4">
         <Button variant="ghost" onClick={onBack} className="gap-2">
@@ -344,6 +345,6 @@ export function GlossaryFlashcards({ onBack }: GlossaryFlashcardsProps) {
           </Button>
         </div>
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/src/components/PracticeTest.tsx
+++ b/src/components/PracticeTest.tsx
@@ -15,6 +15,7 @@ import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { TestType, testConfig } from "@/types/navigation";
+import { PageContainer } from "@/components/ui/page-container";
 interface PracticeTestProps {
   onBack: () => void;
   onTestStateChange?: (inProgress: boolean) => void;
@@ -153,26 +154,30 @@ export function PracticeTest({
   };
 
   if (isLoading) {
-    return <div className="flex-1 bg-background flex items-center justify-center">
+    return (
+      <PageContainer width="narrow" mobileNavPadding className="flex items-center justify-center">
         <div className="text-center">
           <Loader2 className="w-8 h-8 animate-spin text-primary mx-auto mb-4" />
           <p className="text-muted-foreground">Loading questions...</p>
         </div>
-      </div>;
+      </PageContainer>
+    );
   }
   if (error || !allQuestions || allQuestions.length === 0) {
-    return <div className="flex-1 bg-background flex items-center justify-center">
+    return (
+      <PageContainer width="narrow" mobileNavPadding className="flex items-center justify-center">
         <div className="text-center">
           <p className="text-destructive mb-4">Failed to load questions</p>
           <Button onClick={onBack}>Go Back</Button>
         </div>
-      </div>;
+      </PageContainer>
+    );
   }
 
   // Start Screen
   if (!hasStarted) {
-    return <div className="flex-1 bg-background py-8 px-4 pb-24 md:pb-8 overflow-y-auto">
-        <div className="max-w-2xl mx-auto">
+    return (
+      <PageContainer width="narrow" mobileNavPadding>
           {/* Header */}
           <div className="flex items-center justify-between mb-8">
             
@@ -235,16 +240,18 @@ export function PracticeTest({
               Start Test
             </Button>
           </motion.div>
-        </div>
-      </div>;
+      </PageContainer>
+    );
   }
   if (!currentQuestion) {
-    return <div className="flex-1 bg-background flex items-center justify-center">
+    return (
+      <PageContainer width="narrow" mobileNavPadding className="flex items-center justify-center">
         <div className="text-center">
           <p className="text-destructive mb-4">No questions available</p>
           <Button onClick={onBack}>Go Back</Button>
         </div>
-      </div>;
+      </PageContainer>
+    );
   }
 
   const handleFinishInternal = async () => {
@@ -295,9 +302,10 @@ export function PracticeTest({
     return <TestResults questions={questions} answers={answers} onRetake={handleRetake} onBack={onBack} testType={testType} />;
   }
 
-  return <div className="flex-1 bg-background py-8 px-4 pb-24 md:pb-8 overflow-y-auto">
+  return (
+    <PageContainer width="standard" mobileNavPadding>
       {/* Header */}
-      <div className="max-w-3xl mx-auto mb-8">
+      <div className="mb-8">
         <div className="flex items-center justify-between mb-6">
           <div />
           <div className="flex items-center gap-2 text-foreground">
@@ -351,7 +359,7 @@ export function PracticeTest({
       <QuestionCard question={currentQuestion} selectedAnswer={answers[currentQuestion.id] || null} onSelectAnswer={handleSelectAnswer} showResult={false} questionNumber={currentIndex + 1} totalQuestions={questions.length} />
 
       {/* Navigation */}
-      <div className="max-w-3xl mx-auto mt-8">
+      <div className="mt-8">
         <div className="flex items-center justify-between gap-4">
           <Button variant="outline" onClick={handlePrevious} disabled={currentIndex === 0} className="gap-2">
             <ArrowLeft className="w-4 h-4" />
@@ -384,5 +392,6 @@ export function PracticeTest({
             You can still submit, but unanswered questions will be marked incorrect.
           </motion.p>}
       </div>
-    </div>;
+    </PageContainer>
+  );
 }

--- a/src/components/RandomPractice.tsx
+++ b/src/components/RandomPractice.tsx
@@ -14,6 +14,7 @@ import { Zap, SkipForward, RotateCcw, Loader2, Flame, Trophy, Award, ChevronLeft
 import { motion, AnimatePresence } from "framer-motion";
 import { toast } from "sonner";
 import { TestType } from "@/types/navigation";
+import { PageContainer } from "@/components/ui/page-container";
 
 interface HistoryEntry {
   question: Question;
@@ -329,30 +330,37 @@ export function RandomPractice({
   useKeyboardShortcuts(shortcuts, { enabled: !isLoading && !!question });
 
   if (isLoading) {
-    return <div className="min-h-screen bg-background flex items-center justify-center">
+    return (
+      <PageContainer width="standard" mobileNavPadding className="flex items-center justify-center">
         <div className="text-center">
           <Loader2 className="w-8 h-8 animate-spin text-primary mx-auto mb-4" />
           <p className="text-muted-foreground">Loading questions...</p>
         </div>
-      </div>;
+      </PageContainer>
+    );
   }
   if (error || !allQuestions || allQuestions.length === 0) {
-    return <div className="min-h-screen bg-background flex items-center justify-center">
+    return (
+      <PageContainer width="standard" mobileNavPadding className="flex items-center justify-center">
         <div className="text-center">
           <p className="text-destructive mb-4">Failed to load questions</p>
           <Button onClick={onBack}>Go Back</Button>
         </div>
-      </div>;
+      </PageContainer>
+    );
   }
   if (!question) {
-    return <div className="min-h-screen bg-background flex items-center justify-center">
+    return (
+      <PageContainer width="standard" mobileNavPadding className="flex items-center justify-center">
         <Loader2 className="w-8 h-8 animate-spin text-primary" />
-      </div>;
+      </PageContainer>
+    );
   }
 
-  return <div className="flex-1 bg-background py-8 px-4 pb-24 md:pb-8">
+  return (
+    <PageContainer width="standard" mobileNavPadding>
       {/* Header */}
-      <div className="max-w-3xl mx-auto mb-8">
+      <div className="mb-8">
         <div className="flex items-center justify-end mb-6">
           <KeyboardShortcutsHelp />
         </div>
@@ -414,7 +422,7 @@ export function RandomPractice({
       <QuestionCard question={question} selectedAnswer={selectedAnswer} onSelectAnswer={handleSelectAnswer} showResult={showResult} enableGlossaryHighlight onTopicClick={navigateToTopic} />
 
       {/* Actions */}
-      <div className="max-w-3xl mx-auto mt-8 flex justify-center gap-4">
+      <div className="mt-8 flex justify-center gap-4">
         {canGoBack && <Button variant="outline" onClick={handlePreviousQuestion} className="gap-2">
             <ChevronLeft className="w-4 h-4" />
             Previous
@@ -438,6 +446,7 @@ export function RandomPractice({
         </motion.p>}
 
       {/* Keyboard Hint */}
-      
-    </div>;
+
+    </PageContainer>
+  );
 }

--- a/src/components/SubelementPractice.tsx
+++ b/src/components/SubelementPractice.tsx
@@ -12,6 +12,7 @@ import { motion } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { TopicLanding } from "@/components/TopicLanding";
 import { TestType } from "@/types/navigation";
+import { PageContainer } from "@/components/ui/page-container";
 
 interface HistoryEntry {
   question: Question;
@@ -297,27 +298,31 @@ export function SubelementPractice({
   useKeyboardShortcuts(shortcuts, { enabled: topicView === 'practice' });
 
   if (isLoading) {
-    return <div className="flex-1 bg-background flex items-center justify-center">
+    return (
+      <PageContainer width="standard" mobileNavPadding className="flex items-center justify-center">
         <div className="text-center">
           <Loader2 className="w-8 h-8 animate-spin text-primary mx-auto mb-4" />
           <p className="text-muted-foreground">Loading questions...</p>
         </div>
-      </div>;
+      </PageContainer>
+    );
   }
 
   if (error || !allQuestions || allQuestions.length === 0) {
-    return <div className="flex-1 bg-background flex items-center justify-center">
+    return (
+      <PageContainer width="standard" mobileNavPadding className="flex items-center justify-center">
         <div className="text-center">
           <p className="text-destructive mb-4">Failed to load questions</p>
           <Button onClick={onBack}>Go Back</Button>
         </div>
-      </div>;
+      </PageContainer>
+    );
   }
 
   // Show subelement selection list
   if (topicView === 'list' || !selectedSubelement) {
-    return <div className="flex-1 bg-background py-8 px-4 pb-24 md:pb-8 overflow-y-auto">
-      <div className="max-w-3xl mx-auto">
+    return (
+      <PageContainer width="standard" mobileNavPadding>
           <div className="flex items-center justify-end mb-8">
             
           </div>
@@ -368,8 +373,8 @@ export function SubelementPractice({
                 </motion.button>;
           })}
           </div>
-        </div>
-      </div>;
+      </PageContainer>
+    );
   }
 
   // Show topic landing page
@@ -379,18 +384,21 @@ export function SubelementPractice({
 
   // Show practice view
   if (!question) {
-    return <div className="flex-1 bg-background flex items-center justify-center">
+    return (
+      <PageContainer width="standard" mobileNavPadding className="flex items-center justify-center">
         <Loader2 className="w-8 h-8 animate-spin text-primary" />
-      </div>;
+      </PageContainer>
+    );
   }
 
   const isViewingHistory = historyIndex < questionHistory.length - 1;
   const percentage = stats.total > 0 ? Math.round(stats.correct / stats.total * 100) : 0;
   const progress = Math.round(askedIds.length / currentQuestions.length * 100);
 
-  return <div className="flex-1 bg-background py-8 px-4 pb-24 md:pb-8 overflow-y-auto">
+  return (
+    <PageContainer width="standard" mobileNavPadding>
       {/* Header */}
-      <div className="max-w-3xl mx-auto mb-8">
+      <div className="mb-8">
         <div className="flex items-center justify-between mb-6">
           <Button variant="ghost" onClick={handleBackToLanding} className="gap-2">
             <ArrowLeft className="w-4 h-4" />
@@ -458,7 +466,7 @@ export function SubelementPractice({
       <QuestionCard question={question} selectedAnswer={selectedAnswer} onSelectAnswer={handleSelectAnswer} showResult={showResult} enableGlossaryHighlight onTopicClick={navigateToTopic} />
 
       {/* Actions */}
-      <div className="max-w-3xl mx-auto mt-8 flex justify-center gap-4">
+      <div className="mt-8 flex justify-center gap-4">
         {canGoBack && (
           <Button variant="outline" onClick={handlePreviousQuestion} className="gap-2">
             <ChevronLeft className="w-4 h-4" />
@@ -480,13 +488,14 @@ export function SubelementPractice({
 
       {/* History indicator */}
       {questionHistory.length > 1 && (
-        <motion.p 
-          initial={{ opacity: 0 }} 
-          animate={{ opacity: 1 }} 
+        <motion.p
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
           className="text-center text-muted-foreground text-sm mt-4"
         >
           Question {historyIndex + 1} of {questionHistory.length}
         </motion.p>
       )}
-    </div>;
+    </PageContainer>
+  );
 }

--- a/src/components/TestResultReview.tsx
+++ b/src/components/TestResultReview.tsx
@@ -8,6 +8,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { ArrowLeft, ArrowRight, Trophy, XCircle, Loader2, Calendar } from "lucide-react";
 import { motion } from "framer-motion";
 import { cn } from "@/lib/utils";
+import { PageContainer } from "@/components/ui/page-container";
 
 interface TestResultReviewProps {
   testResultId: string;
@@ -58,20 +59,20 @@ export function TestResultReview({ testResultId, onBack }: TestResultReviewProps
 
   if (resultLoading || attemptsLoading || !allQuestions) {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
+      <PageContainer width="narrow" className="flex items-center justify-center">
         <Loader2 className="w-8 h-8 animate-spin text-primary" />
-      </div>
+      </PageContainer>
     );
   }
 
   if (!testResult || !attempts) {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
+      <PageContainer width="narrow" className="flex items-center justify-center">
         <div className="text-center">
           <p className="text-destructive mb-4">Test result not found</p>
           <Button onClick={onBack}>Go Back</Button>
         </div>
-      </div>
+      </PageContainer>
     );
   }
 
@@ -96,8 +97,8 @@ export function TestResultReview({ testResultId, onBack }: TestResultReviewProps
   if (reviewIndex !== null && questions[reviewIndex]) {
     const question = questions[reviewIndex];
     return (
-      <div className="min-h-screen bg-background py-8 px-4">
-        <div className="max-w-3xl mx-auto mb-8">
+      <PageContainer width="standard">
+        <div className="mb-8">
           <Button
             variant="ghost"
             onClick={() => setReviewIndex(null)}
@@ -119,7 +120,7 @@ export function TestResultReview({ testResultId, onBack }: TestResultReviewProps
           onTopicClick={navigateToTopic}
         />
 
-        <div className="max-w-3xl mx-auto mt-8 flex justify-between">
+        <div className="mt-8 flex justify-between">
           <Button
             variant="outline"
             onClick={() => setReviewIndex(Math.max(0, reviewIndex - 1))}
@@ -141,14 +142,12 @@ export function TestResultReview({ testResultId, onBack }: TestResultReviewProps
             <ArrowRight className="w-4 h-4" />
           </Button>
         </div>
-      </div>
+      </PageContainer>
     );
   }
 
   return (
-    <div className="h-full flex flex-col bg-background radio-wave-bg">
-      <div className="flex-1 flex flex-col overflow-hidden py-6 px-4">
-        <div className="max-w-2xl mx-auto w-full flex flex-col flex-1 overflow-hidden">
+    <PageContainer width="narrow" radioWaveBg className="flex flex-col h-full" contentClassName="flex flex-col flex-1 overflow-hidden">
 
           {/* Result Header - Fixed */}
           <motion.div
@@ -265,8 +264,6 @@ export function TestResultReview({ testResultId, onBack }: TestResultReviewProps
               })}
             </div>
           </motion.div>
-        </div>
-      </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/src/components/TestResults.tsx
+++ b/src/components/TestResults.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft, ArrowRight, RotateCcw, Home, Trophy, XCircle } from "lucide-
 import { motion } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { TestType, testConfig } from "@/types/navigation";
+import { PageContainer } from "@/components/ui/page-container";
 
 interface TestResultsProps {
   questions: Question[];
@@ -33,8 +34,8 @@ export function TestResults({ questions, answers, onRetake, onBack, testType = '
   if (reviewIndex !== null) {
     const question = questions[reviewIndex];
     return (
-      <div className="flex-1 bg-background py-8 px-4 pb-24 md:pb-8 overflow-y-auto">
-        <div className="max-w-3xl mx-auto mb-8">
+      <PageContainer width="standard" mobileNavPadding>
+        <div className="mb-8">
           <Button
             variant="ghost"
             onClick={() => setReviewIndex(null)}
@@ -54,7 +55,7 @@ export function TestResults({ questions, answers, onRetake, onBack, testType = '
           totalQuestions={totalQuestions}
         />
 
-        <div className="max-w-3xl mx-auto mt-8 flex justify-between">
+        <div className="mt-8 flex justify-between">
           <Button
             variant="outline"
             onClick={() => setReviewIndex(Math.max(0, reviewIndex - 1))}
@@ -76,13 +77,12 @@ export function TestResults({ questions, answers, onRetake, onBack, testType = '
             <ArrowRight className="w-4 h-4" />
           </Button>
         </div>
-      </div>
+      </PageContainer>
     );
   }
 
   return (
-    <div className="flex-1 bg-background py-8 px-4 pb-24 md:pb-8 overflow-y-auto radio-wave-bg">
-      <div className="max-w-2xl mx-auto">
+    <PageContainer width="narrow" mobileNavPadding radioWaveBg>
         {/* Result Header */}
         <motion.div
           initial={{ opacity: 0, scale: 0.9 }}
@@ -212,7 +212,6 @@ export function TestResults({ questions, answers, onRetake, onBack, testType = '
             })}
           </div>
         </motion.div>
-      </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/src/components/TopicDetailPage.tsx
+++ b/src/components/TopicDetailPage.tsx
@@ -11,6 +11,7 @@ import { ArrowLeft, BookOpen } from "lucide-react";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
+import { PageContainer } from "@/components/ui/page-container";
 
 interface TopicDetailPageProps {
   slug: string;
@@ -30,44 +31,42 @@ export function TopicDetailPage({ slug, onBack }: TopicDetailPageProps) {
   // Loading state
   if (topicLoading) {
     return (
-      <div className="flex-1 py-8 px-4 md:px-8">
-        <div className="max-w-7xl mx-auto">
-          {/* Header skeleton */}
-          <div className="mb-8">
-            <Skeleton className="h-8 w-48 mb-2" />
-            <Skeleton className="h-10 w-3/4 mb-4" />
-            <div className="flex gap-2">
-              <Skeleton className="h-6 w-16" />
-              <Skeleton className="h-6 w-16" />
-            </div>
-          </div>
-          {/* Content skeleton */}
-          <div className="grid grid-cols-1 lg:grid-cols-[200px_1fr_250px] gap-8">
-            <div className="hidden lg:block">
-              <Skeleton className="h-48 w-full" />
-            </div>
-            <div>
-              <Skeleton className="h-6 w-full mb-4" />
-              <Skeleton className="h-4 w-full mb-2" />
-              <Skeleton className="h-4 w-3/4 mb-2" />
-              <Skeleton className="h-4 w-5/6 mb-4" />
-              <Skeleton className="h-6 w-2/3 mb-4" />
-              <Skeleton className="h-4 w-full mb-2" />
-              <Skeleton className="h-4 w-4/5" />
-            </div>
-            <div className="hidden lg:block">
-              <Skeleton className="h-64 w-full" />
-            </div>
+      <PageContainer width="full">
+        {/* Header skeleton */}
+        <div className="mb-8">
+          <Skeleton className="h-8 w-48 mb-2" />
+          <Skeleton className="h-10 w-3/4 mb-4" />
+          <div className="flex gap-2">
+            <Skeleton className="h-6 w-16" />
+            <Skeleton className="h-6 w-16" />
           </div>
         </div>
-      </div>
+        {/* Content skeleton */}
+        <div className="grid grid-cols-1 lg:grid-cols-[200px_1fr_250px] gap-8">
+          <div className="hidden lg:block">
+            <Skeleton className="h-48 w-full" />
+          </div>
+          <div>
+            <Skeleton className="h-6 w-full mb-4" />
+            <Skeleton className="h-4 w-full mb-2" />
+            <Skeleton className="h-4 w-3/4 mb-2" />
+            <Skeleton className="h-4 w-5/6 mb-4" />
+            <Skeleton className="h-6 w-2/3 mb-4" />
+            <Skeleton className="h-4 w-full mb-2" />
+            <Skeleton className="h-4 w-4/5" />
+          </div>
+          <div className="hidden lg:block">
+            <Skeleton className="h-64 w-full" />
+          </div>
+        </div>
+      </PageContainer>
     );
   }
 
   // Error state
   if (topicError || !topic) {
     return (
-      <div className="flex-1 flex items-center justify-center py-12">
+      <PageContainer width="full" className="flex items-center justify-center">
         <div className="text-center">
           <BookOpen className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
           <h2 className="text-lg font-medium text-foreground mb-2">Topic not found</h2>
@@ -79,7 +78,7 @@ export function TopicDetailPage({ slug, onBack }: TopicDetailPageProps) {
             Back to Topics
           </Button>
         </div>
-      </div>
+      </PageContainer>
     );
   }
 
@@ -87,7 +86,7 @@ export function TopicDetailPage({ slug, onBack }: TopicDetailPageProps) {
   const displayContent = content || `# ${topic.title}\n\n${topic.description || "Content coming soon..."}\n\nThis topic is still being developed. Check back later for the full article.`;
 
   return (
-    <div className="flex-1">
+    <div className="flex-1 overflow-y-auto">
       {/* Header */}
       <motion.div
         initial={{ opacity: 0, y: -10 }}
@@ -136,7 +135,7 @@ export function TopicDetailPage({ slug, onBack }: TopicDetailPageProps) {
       </motion.div>
 
       {/* Main content area - three column layout */}
-      <div className="max-w-7xl mx-auto px-4 md:px-8 py-8">
+      <div className="max-w-7xl mx-auto px-4 md:px-8 py-8 md:py-12">
         <div className="grid grid-cols-1 lg:grid-cols-[200px_1fr_280px] gap-8">
           {/* Left sidebar - Table of Contents */}
           <motion.aside

--- a/src/components/TopicGallery.tsx
+++ b/src/components/TopicGallery.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Search, BookOpen } from "lucide-react";
 import { TestType } from "@/types/navigation";
+import { PageContainer } from "@/components/ui/page-container";
 
 interface TopicGalleryProps {
   testType?: TestType;
@@ -46,8 +47,7 @@ export function TopicGallery({ testType }: TopicGalleryProps) {
   }
 
   return (
-    <div className="flex-1 overflow-y-auto py-8 md:py-12 px-4 md:px-8">
-      <div className="max-w-6xl mx-auto space-y-8">
+    <PageContainer width="wide" contentClassName="space-y-8">
         {/* Header */}
         <motion.div
           initial={{ opacity: 0, y: 10 }}
@@ -132,7 +132,6 @@ export function TopicGallery({ testType }: TopicGalleryProps) {
             )}
           </div>
         )}
-      </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/src/components/TopicLanding.tsx
+++ b/src/components/TopicLanding.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { BookOpen, Play, ExternalLink, ArrowLeft } from "lucide-react";
 import { motion } from "framer-motion";
 import { cn } from "@/lib/utils";
+import { PageContainer } from "@/components/ui/page-container";
 
 interface TopicLandingProps {
   subelement: string;
@@ -71,8 +72,7 @@ export function TopicLanding({
   const websiteLinks = topicLinks.filter(l => l.type === 'website');
 
   return (
-    <div className="flex-1 bg-background py-8 px-4 pb-24 md:pb-8 overflow-y-auto">
-      <div className="max-w-3xl mx-auto">
+    <PageContainer width="standard" mobileNavPadding>
         {/* Back to All Topics */}
         <div className="mb-6">
           <Button variant="ghost" onClick={onBack} className="gap-2">
@@ -213,7 +213,6 @@ export function TopicLanding({
             </p>
           </motion.div>
         )}
-      </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/src/components/WeakQuestionsReview.tsx
+++ b/src/components/WeakQuestionsReview.tsx
@@ -14,6 +14,7 @@ import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { motion } from "framer-motion";
 import { TestType } from "@/types/navigation";
+import { PageContainer } from "@/components/ui/page-container";
 
 // Number of correct answers in a row needed to clear a weak question
 const STREAK_TO_CLEAR = 3;
@@ -203,18 +204,20 @@ export function WeakQuestionsReview({
   useKeyboardShortcuts(shortcuts, { enabled: !!currentQuestion });
 
   if (isLoading) {
-    return <div className="flex-1 bg-background flex items-center justify-center">
+    return (
+      <PageContainer width="standard" mobileNavPadding className="flex items-center justify-center">
         <div className="text-center">
           <Loader2 className="w-8 h-8 animate-spin text-primary mx-auto mb-4" />
           <p className="text-muted-foreground">Loading questions...</p>
         </div>
-      </div>;
+      </PageContainer>
+    );
   }
   // Empty state - no weak questions or all cleared
   if (error || activeWeakQuestions.length === 0) {
     const allCleared = clearedQuestions.size > 0 && weakQuestions.length > 0;
-    return <div className="flex-1 bg-background py-8 px-4 pb-24 md:pb-8 overflow-y-auto">
-      <div className="max-w-3xl mx-auto">
+    return (
+      <PageContainer width="standard" mobileNavPadding>
         <Card>
           <CardContent className="pt-6">
             <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="text-center py-8">
@@ -231,8 +234,8 @@ export function WeakQuestionsReview({
             </motion.div>
           </CardContent>
         </Card>
-      </div>
-    </div>;
+      </PageContainer>
+    );
   }
 
   // Question detail view
@@ -241,8 +244,9 @@ export function WeakQuestionsReview({
     const isJustCleared = justClearedQuestion !== null;
     const hasMoreQuestions = activeWeakQuestions.length > 0;
 
-    return <div className="flex-1 bg-background py-8 px-4 pb-24 md:pb-8 overflow-y-auto">
-      <div className="max-w-3xl mx-auto mb-8">
+    return (
+      <PageContainer width="standard" mobileNavPadding>
+        <div className="mb-8">
         <div className="flex items-center justify-between mb-6">
           <Button variant="ghost" onClick={handleBackToList} className="gap-2">
             <ArrowLeft className="w-4 h-4" />
@@ -313,7 +317,7 @@ export function WeakQuestionsReview({
       <QuestionCard question={currentQuestion} selectedAnswer={selectedAnswer} onSelectAnswer={handleSelectAnswer} showResult={showResult} enableGlossaryHighlight onTopicClick={navigateToTopic} />
 
       {/* Navigation Actions */}
-      <div className="max-w-3xl mx-auto mt-8 flex justify-center gap-4">
+      <div className="mt-8 flex justify-center gap-4">
         <Button variant="outline" onClick={handlePrevQuestion} disabled={!canGoPrev || isJustCleared} className="gap-2">
           <ChevronLeft className="w-4 h-4" />
           Previous
@@ -346,12 +350,13 @@ export function WeakQuestionsReview({
           <span className="text-success ml-2">({clearedQuestions.size} cleared)</span>
         )}
       </motion.p>}
-    </div>;
+      </PageContainer>
+    );
   }
 
   // List view - show all weak questions
-  return <div className="flex-1 bg-background py-8 px-4 pb-24 md:pb-8 overflow-y-auto">
-    <div className="max-w-3xl mx-auto">
+  return (
+    <PageContainer width="standard" mobileNavPadding>
       <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="space-y-3">
         <div className="flex flex-col gap-4 mb-4">
           <div className="flex items-center justify-between">
@@ -417,6 +422,6 @@ export function WeakQuestionsReview({
           );
         })}
       </motion.div>
-    </div>
-  </div>;
+    </PageContainer>
+  );
 }

--- a/src/components/ui/page-container.test.tsx
+++ b/src/components/ui/page-container.test.tsx
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PageContainer } from './page-container';
+
+describe('PageContainer', () => {
+  it('renders children correctly', () => {
+    render(
+      <PageContainer>
+        <p>Test content</p>
+      </PageContainer>
+    );
+    expect(screen.getByText('Test content')).toBeInTheDocument();
+  });
+
+  it('applies default standard width class', () => {
+    const { container } = render(
+      <PageContainer>
+        <p>Content</p>
+      </PageContainer>
+    );
+    const innerContainer = container.querySelector('.max-w-3xl');
+    expect(innerContainer).toBeInTheDocument();
+  });
+
+  describe('width prop', () => {
+    it('applies narrow width class (max-w-2xl)', () => {
+      const { container } = render(
+        <PageContainer width="narrow">
+          <p>Narrow content</p>
+        </PageContainer>
+      );
+      expect(container.querySelector('.max-w-2xl')).toBeInTheDocument();
+      expect(container.querySelector('.max-w-3xl')).not.toBeInTheDocument();
+    });
+
+    it('applies standard width class (max-w-3xl)', () => {
+      const { container } = render(
+        <PageContainer width="standard">
+          <p>Standard content</p>
+        </PageContainer>
+      );
+      expect(container.querySelector('.max-w-3xl')).toBeInTheDocument();
+    });
+
+    it('applies wide width class (max-w-5xl)', () => {
+      const { container } = render(
+        <PageContainer width="wide">
+          <p>Wide content</p>
+        </PageContainer>
+      );
+      expect(container.querySelector('.max-w-5xl')).toBeInTheDocument();
+      expect(container.querySelector('.max-w-3xl')).not.toBeInTheDocument();
+    });
+
+    it('applies full width class (max-w-7xl)', () => {
+      const { container } = render(
+        <PageContainer width="full">
+          <p>Full content</p>
+        </PageContainer>
+      );
+      expect(container.querySelector('.max-w-7xl')).toBeInTheDocument();
+      expect(container.querySelector('.max-w-3xl')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('mobileNavPadding prop', () => {
+    it('does not apply pb-24 class by default', () => {
+      const { container } = render(
+        <PageContainer>
+          <p>Content</p>
+        </PageContainer>
+      );
+      const outerContainer = container.firstChild as HTMLElement;
+      expect(outerContainer).not.toHaveClass('pb-24');
+    });
+
+    it('applies pb-24 class when mobileNavPadding is true', () => {
+      const { container } = render(
+        <PageContainer mobileNavPadding>
+          <p>Content</p>
+        </PageContainer>
+      );
+      const outerContainer = container.firstChild as HTMLElement;
+      expect(outerContainer).toHaveClass('pb-24');
+    });
+  });
+
+  describe('radioWaveBg prop', () => {
+    it('does not apply radio-wave-bg class by default', () => {
+      const { container } = render(
+        <PageContainer>
+          <p>Content</p>
+        </PageContainer>
+      );
+      const outerContainer = container.firstChild as HTMLElement;
+      expect(outerContainer).not.toHaveClass('radio-wave-bg');
+    });
+
+    it('applies radio-wave-bg class when radioWaveBg is true', () => {
+      const { container } = render(
+        <PageContainer radioWaveBg>
+          <p>Content</p>
+        </PageContainer>
+      );
+      const outerContainer = container.firstChild as HTMLElement;
+      expect(outerContainer).toHaveClass('radio-wave-bg');
+    });
+  });
+
+  describe('className prop', () => {
+    it('applies custom className to outer container', () => {
+      const { container } = render(
+        <PageContainer className="custom-outer-class">
+          <p>Content</p>
+        </PageContainer>
+      );
+      const outerContainer = container.firstChild as HTMLElement;
+      expect(outerContainer).toHaveClass('custom-outer-class');
+    });
+
+    it('preserves default classes when adding custom className', () => {
+      const { container } = render(
+        <PageContainer className="custom-class">
+          <p>Content</p>
+        </PageContainer>
+      );
+      const outerContainer = container.firstChild as HTMLElement;
+      expect(outerContainer).toHaveClass('flex-1');
+      expect(outerContainer).toHaveClass('overflow-y-auto');
+      expect(outerContainer).toHaveClass('custom-class');
+    });
+  });
+
+  describe('contentClassName prop', () => {
+    it('applies custom contentClassName to inner container', () => {
+      const { container } = render(
+        <PageContainer contentClassName="custom-inner-class">
+          <p>Content</p>
+        </PageContainer>
+      );
+      const innerContainer = container.querySelector('.mx-auto');
+      expect(innerContainer).toHaveClass('custom-inner-class');
+    });
+
+    it('preserves width and mx-auto classes when adding contentClassName', () => {
+      const { container } = render(
+        <PageContainer width="wide" contentClassName="flex flex-col">
+          <p>Content</p>
+        </PageContainer>
+      );
+      const innerContainer = container.querySelector('.max-w-5xl');
+      expect(innerContainer).toHaveClass('mx-auto');
+      expect(innerContainer).toHaveClass('flex');
+      expect(innerContainer).toHaveClass('flex-col');
+    });
+  });
+
+  describe('default styling', () => {
+    it('applies base padding classes', () => {
+      const { container } = render(
+        <PageContainer>
+          <p>Content</p>
+        </PageContainer>
+      );
+      const outerContainer = container.firstChild as HTMLElement;
+      expect(outerContainer).toHaveClass('py-8');
+      expect(outerContainer).toHaveClass('px-4');
+    });
+
+    it('applies mx-auto to center content', () => {
+      const { container } = render(
+        <PageContainer>
+          <p>Content</p>
+        </PageContainer>
+      );
+      const innerContainer = container.querySelector('.mx-auto');
+      expect(innerContainer).toBeInTheDocument();
+    });
+  });
+
+  describe('combined props', () => {
+    it('applies multiple props correctly', () => {
+      const { container } = render(
+        <PageContainer
+          width="wide"
+          mobileNavPadding
+          radioWaveBg
+          className="custom-outer"
+          contentClassName="custom-inner"
+        >
+          <p>Content</p>
+        </PageContainer>
+      );
+
+      const outerContainer = container.firstChild as HTMLElement;
+      expect(outerContainer).toHaveClass('pb-24');
+      expect(outerContainer).toHaveClass('radio-wave-bg');
+      expect(outerContainer).toHaveClass('custom-outer');
+
+      const innerContainer = container.querySelector('.max-w-5xl');
+      expect(innerContainer).toHaveClass('custom-inner');
+      expect(innerContainer).toHaveClass('mx-auto');
+    });
+  });
+});

--- a/src/components/ui/page-container.tsx
+++ b/src/components/ui/page-container.tsx
@@ -1,0 +1,48 @@
+import { cn } from "@/lib/utils";
+import { ReactNode } from "react";
+
+interface PageContainerProps {
+  children: ReactNode;
+  /** Max-width tier: narrow (2xl), standard (3xl), wide (5xl), full (7xl) */
+  width?: 'narrow' | 'standard' | 'wide' | 'full';
+  /** Add extra bottom padding for mobile nav (for views with bottom action buttons) */
+  mobileNavPadding?: boolean;
+  /** Apply the radio-wave background effect */
+  radioWaveBg?: boolean;
+  /** Additional className for the outer container */
+  className?: string;
+  /** Additional className for the inner content container */
+  contentClassName?: string;
+}
+
+const widthClasses = {
+  narrow: 'max-w-2xl',
+  standard: 'max-w-3xl',
+  wide: 'max-w-5xl',
+  full: 'max-w-7xl',
+};
+
+export function PageContainer({
+  children,
+  width = 'standard',
+  mobileNavPadding = false,
+  radioWaveBg = false,
+  className,
+  contentClassName,
+}: PageContainerProps) {
+  return (
+    <div
+      className={cn(
+        'flex-1 overflow-y-auto',
+        'py-8 md:py-12 px-4 md:px-8',
+        mobileNavPadding && 'pb-24 md:pb-8',
+        radioWaveBg && 'radio-wave-bg',
+        className
+      )}
+    >
+      <div className={cn(widthClasses[width], 'mx-auto', contentClassName)}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -11,6 +11,7 @@ import { calculateWeakQuestionIds } from '@/lib/weakQuestions';
 import { filterByTestType } from '@/lib/testTypeUtils';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { Loader2, AlertTriangle } from 'lucide-react';
+import { PageContainer } from '@/components/ui/page-container';
 import {
   DashboardStats,
   DashboardWeeklyGoals,
@@ -296,8 +297,7 @@ export default function Dashboard() {
     };
 
     return (
-      <div className="flex-1 overflow-y-auto py-8 md:py-12 px-4 md:px-8 radio-wave-bg">
-        <div className="max-w-3xl mx-auto">
+      <PageContainer width="standard" radioWaveBg>
           <DashboardReadiness
             readinessLevel={readinessLevel}
             readinessTitle={readinessTitle}
@@ -342,8 +342,7 @@ export default function Dashboard() {
               onReviewWeakQuestions={() => changeView('weak-questions')}
             />
           </div>
-        </div>
-      </div>
+      </PageContainer>
     );
   };
   return <>


### PR DESCRIPTION
## Summary
- Created a reusable `PageContainer` component that standardizes layout across all views
- Consolidated 6+ different max-width patterns into 4 consistent width tiers: narrow, standard, wide, full
- Standardized padding to `py-8 md:py-12 px-4 md:px-8` across all pages
- Added optional `mobileNavPadding` prop for views with bottom action buttons
- Updated 14 components to use the new PageContainer

## Changes
| Width Tier | Class | Use Case |
|------------|-------|----------|
| `narrow` | `max-w-2xl` | Results screens, flashcards |
| `standard` | `max-w-3xl` | Question practice, interactive views |
| `wide` | `max-w-5xl` | Galleries, glossary, search results |
| `full` | `max-w-7xl` | Three-column layouts |

## Test plan
- [x] Unit tests added for PageContainer component (17 tests)
- [x] All 2259 existing tests pass
- [x] TypeScript compilation passes
- [ ] Verify consistent layouts across all views on desktop
- [ ] Verify mobile layouts and bottom nav clearance
- [ ] Test both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)