### PR TITLE
fix: bypass Supabase 1000 row limit for question queries

### DIFF
--- a/src/components/admin/TopicQuestionManager.test.tsx
+++ b/src/components/admin/TopicQuestionManager.test.tsx
@@ -64,9 +64,11 @@ describe('TopicQuestionManager', () => {
       if (table === 'questions') {
         return {
           select: vi.fn().mockReturnValue({
-            order: vi.fn().mockResolvedValue({
-              data: mockQuestions,
-              error: null,
+            order: vi.fn().mockReturnValue({
+              range: vi.fn().mockResolvedValue({
+                data: mockQuestions,
+                error: null,
+              }),
             }),
           }),
         };
@@ -90,7 +92,9 @@ describe('TopicQuestionManager', () => {
       return {
         select: vi.fn().mockReturnValue({
           eq: vi.fn().mockResolvedValue({ data: [], error: null }),
-          order: vi.fn().mockResolvedValue({ data: [], error: null }),
+          order: vi.fn().mockReturnValue({
+            range: vi.fn().mockResolvedValue({ data: [], error: null }),
+          }),
         }),
       };
     });
@@ -308,9 +312,11 @@ describe('TopicQuestionManager', () => {
         if (table === 'questions') {
           return {
             select: vi.fn().mockReturnValue({
-              order: vi.fn().mockResolvedValue({
-                data: mockQuestions,
-                error: null,
+              order: vi.fn().mockReturnValue({
+                range: vi.fn().mockResolvedValue({
+                  data: mockQuestions,
+                  error: null,
+                }),
               }),
             }),
           };
@@ -359,9 +365,11 @@ describe('TopicQuestionManager', () => {
         if (table === 'questions') {
           return {
             select: vi.fn().mockReturnValue({
-              order: vi.fn().mockResolvedValue({
-                data: mockQuestions,
-                error: null,
+              order: vi.fn().mockReturnValue({
+                range: vi.fn().mockResolvedValue({
+                  data: mockQuestions,
+                  error: null,
+                }),
               }),
             }),
           };
@@ -406,9 +414,11 @@ describe('TopicQuestionManager', () => {
         if (table === 'questions') {
           return {
             select: vi.fn().mockReturnValue({
-              order: vi.fn().mockResolvedValue({
-                data: mockQuestions,
-                error: null,
+              order: vi.fn().mockReturnValue({
+                range: vi.fn().mockResolvedValue({
+                  data: mockQuestions,
+                  error: null,
+                }),
               }),
             }),
           };
@@ -455,9 +465,11 @@ describe('TopicQuestionManager', () => {
         if (table === 'questions') {
           return {
             select: vi.fn().mockReturnValue({
-              order: vi.fn().mockResolvedValue({
-                data: mockQuestions,
-                error: null,
+              order: vi.fn().mockReturnValue({
+                range: vi.fn().mockResolvedValue({
+                  data: mockQuestions,
+                  error: null,
+                }),
               }),
             }),
           };
@@ -503,9 +515,11 @@ describe('TopicQuestionManager', () => {
         if (table === 'questions') {
           return {
             select: vi.fn().mockReturnValue({
-              order: vi.fn().mockResolvedValue({
-                data: mockQuestions,
-                error: null,
+              order: vi.fn().mockReturnValue({
+                range: vi.fn().mockResolvedValue({
+                  data: mockQuestions,
+                  error: null,
+                }),
               }),
             }),
           };
@@ -572,9 +586,11 @@ describe('TopicQuestionManager', () => {
         if (table === 'questions') {
           return {
             select: vi.fn().mockReturnValue({
-              order: vi.fn().mockResolvedValue({
-                data: mockQuestions,
-                error: null,
+              order: vi.fn().mockReturnValue({
+                range: vi.fn().mockResolvedValue({
+                  data: mockQuestions,
+                  error: null,
+                }),
               }),
             }),
           };

--- a/src/components/admin/TopicQuestionManager.tsx
+++ b/src/components/admin/TopicQuestionManager.tsx
@@ -25,14 +25,15 @@ export function TopicQuestionManager({ topicId }: TopicQuestionManagerProps) {
   const [searchTerm, setSearchTerm] = useState("");
   const [testTypeFilter, setTestTypeFilter] = useState<string>("all");
 
-  // Fetch all questions
+  // Fetch all questions (using range to bypass Supabase's default 1000 row limit)
   const { data: allQuestions = [], isLoading: questionsLoading } = useQuery({
     queryKey: ["all-questions-for-linking"],
     queryFn: async () => {
       const { data, error } = await supabase
         .from("questions")
         .select("id, display_name, question")
-        .order("display_name", { ascending: true });
+        .order("display_name", { ascending: true })
+        .range(0, 1999); // Fetch up to 2000 questions to cover all license types
 
       if (error) throw error;
       return data as Question[];

--- a/src/hooks/useQuestions.test.tsx
+++ b/src/hooks/useQuestions.test.tsx
@@ -5,7 +5,8 @@ import { ReactNode } from 'react';
 import { useQuestions, useQuestion } from './useQuestions';
 
 // Mock Supabase
-const mockSelect = vi.fn();
+const mockRange = vi.fn();
+const mockSelect = vi.fn(() => ({ range: mockRange }));
 const mockSingleQuery = vi.fn();
 
 vi.mock('@/integrations/supabase/client', () => ({
@@ -46,7 +47,7 @@ function createWrapper() {
 describe('useQuestions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockSelect.mockResolvedValue({ data: mockDbQuestions, error: null });
+    mockRange.mockResolvedValue({ data: mockDbQuestions, error: null });
   });
 
   describe('without testType filter', () => {
@@ -151,7 +152,7 @@ describe('useQuestions', () => {
 
   describe('correct answer mapping', () => {
     it('maps correct_answer 0 to A', async () => {
-      mockSelect.mockResolvedValueOnce({
+      mockRange.mockResolvedValueOnce({
         data: [{ id: 'uuid-t1a01', display_name: 'T1A01', question: 'Q?', options: ['A', 'B', 'C', 'D'], correct_answer: 0, subelement: 'T1', question_group: 'T1A', links: [], explanation: null }],
         error: null,
       });
@@ -163,7 +164,7 @@ describe('useQuestions', () => {
     });
 
     it('maps correct_answer 1 to B', async () => {
-      mockSelect.mockResolvedValueOnce({
+      mockRange.mockResolvedValueOnce({
         data: [{ id: 'uuid-t1a01', display_name: 'T1A01', question: 'Q?', options: ['A', 'B', 'C', 'D'], correct_answer: 1, subelement: 'T1', question_group: 'T1A', links: [], explanation: null }],
         error: null,
       });
@@ -175,7 +176,7 @@ describe('useQuestions', () => {
     });
 
     it('maps correct_answer 2 to C', async () => {
-      mockSelect.mockResolvedValueOnce({
+      mockRange.mockResolvedValueOnce({
         data: [{ id: 'uuid-t1a01', display_name: 'T1A01', question: 'Q?', options: ['A', 'B', 'C', 'D'], correct_answer: 2, subelement: 'T1', question_group: 'T1A', links: [], explanation: null }],
         error: null,
       });
@@ -187,7 +188,7 @@ describe('useQuestions', () => {
     });
 
     it('maps correct_answer 3 to D', async () => {
-      mockSelect.mockResolvedValueOnce({
+      mockRange.mockResolvedValueOnce({
         data: [{ id: 'uuid-t1a01', display_name: 'T1A01', question: 'Q?', options: ['A', 'B', 'C', 'D'], correct_answer: 3, subelement: 'T1', question_group: 'T1A', links: [], explanation: null }],
         error: null,
       });
@@ -201,7 +202,7 @@ describe('useQuestions', () => {
 
   describe('error handling', () => {
     it('returns error state when query fails', async () => {
-      mockSelect.mockResolvedValueOnce({
+      mockRange.mockResolvedValueOnce({
         data: null,
         error: new Error('Database error'),
       });
@@ -218,7 +219,7 @@ describe('useQuestions', () => {
   describe('empty results', () => {
     it('returns empty array when no questions match filter', async () => {
       // Only return Technician questions from the database
-      mockSelect.mockResolvedValueOnce({
+      mockRange.mockResolvedValueOnce({
         data: [
           { id: 'uuid-t1a01', display_name: 'T1A01', question: 'Tech Q?', options: ['A', 'B', 'C', 'D'], correct_answer: 0, subelement: 'T1', question_group: 'T1A', links: [], explanation: null, forum_url: null },
         ],
@@ -238,7 +239,7 @@ describe('useQuestions', () => {
 
   describe('forum_url handling', () => {
     it('transforms forum_url to forumUrl in camelCase', async () => {
-      mockSelect.mockResolvedValueOnce({
+      mockRange.mockResolvedValueOnce({
         data: [
           { id: 'uuid-t1a01', display_name: 'T1A01', question: 'Q?', options: ['A', 'B', 'C', 'D'], correct_answer: 0, subelement: 'T1', question_group: 'T1A', links: [], explanation: null, forum_url: 'https://forum.openhamprep.com/t/test/123' },
         ],
@@ -252,7 +253,7 @@ describe('useQuestions', () => {
     });
 
     it('handles null forum_url', async () => {
-      mockSelect.mockResolvedValueOnce({
+      mockRange.mockResolvedValueOnce({
         data: [
           { id: 'uuid-t1a01', display_name: 'T1A01', question: 'Q?', options: ['A', 'B', 'C', 'D'], correct_answer: 0, subelement: 'T1', question_group: 'T1A', links: [], explanation: null, forum_url: null },
         ],
@@ -282,7 +283,7 @@ describe('useQuestions', () => {
     });
 
     it('includes forumUrl in Question interface', async () => {
-      mockSelect.mockResolvedValueOnce({
+      mockRange.mockResolvedValueOnce({
         data: [
           { id: 'uuid-t1a01', display_name: 'T1A01', question: 'Q?', options: ['A', 'B', 'C', 'D'], correct_answer: 0, subelement: 'T1', question_group: 'T1A', links: [], explanation: 'Test explanation', forum_url: 'https://forum.openhamprep.com/t/test/456', figure_url: null },
         ],
@@ -309,7 +310,7 @@ describe('useQuestions', () => {
 
   describe('figure_url handling', () => {
     it('transforms figure_url to figureUrl in camelCase', async () => {
-      mockSelect.mockResolvedValueOnce({
+      mockRange.mockResolvedValueOnce({
         data: [
           { id: 'uuid-e9b05', display_name: 'E9B05', question: 'What is shown in Figure E9-2?', options: ['A', 'B', 'C', 'D'], correct_answer: 0, subelement: 'E9', question_group: 'E9B', links: [], explanation: null, forum_url: null, figure_url: 'https://storage.example.com/question-figures/E9B05.png' },
         ],
@@ -323,7 +324,7 @@ describe('useQuestions', () => {
     });
 
     it('handles null figure_url', async () => {
-      mockSelect.mockResolvedValueOnce({
+      mockRange.mockResolvedValueOnce({
         data: [
           { id: 'uuid-t1a01', display_name: 'T1A01', question: 'Q?', options: ['A', 'B', 'C', 'D'], correct_answer: 0, subelement: 'T1', question_group: 'T1A', links: [], explanation: null, forum_url: null, figure_url: null },
         ],
@@ -353,7 +354,7 @@ describe('useQuestions', () => {
     });
 
     it('includes figureUrl in Question interface', async () => {
-      mockSelect.mockResolvedValueOnce({
+      mockRange.mockResolvedValueOnce({
         data: [
           { id: 'uuid-e9b05', display_name: 'E9B05', question: 'What is shown in Figure E9-2?', options: ['A', 'B', 'C', 'D'], correct_answer: 0, subelement: 'E9', question_group: 'E9B', links: [], explanation: 'Antenna pattern explanation', forum_url: null, figure_url: 'https://storage.example.com/question-figures/E9B05.png' },
         ],
@@ -374,7 +375,7 @@ describe('useQuestions', () => {
     });
 
     it('handles question with both forumUrl and figureUrl', async () => {
-      mockSelect.mockResolvedValueOnce({
+      mockRange.mockResolvedValueOnce({
         data: [
           {
             id: 'uuid-e9b05',
@@ -403,7 +404,7 @@ describe('useQuestions', () => {
 
     it('handles Supabase storage URLs correctly', async () => {
       const storageUrl = 'https://xyz.supabase.co/storage/v1/object/public/question-figures/E9B05.png';
-      mockSelect.mockResolvedValueOnce({
+      mockRange.mockResolvedValueOnce({
         data: [
           { id: 'uuid-e9b05', display_name: 'E9B05', question: 'Q?', options: ['A', 'B', 'C', 'D'], correct_answer: 0, subelement: 'E9', question_group: 'E9B', links: [], explanation: null, forum_url: null, figure_url: storageUrl },
         ],
@@ -418,7 +419,7 @@ describe('useQuestions', () => {
 
     it('handles figure URLs with cache-busting query parameters', async () => {
       const urlWithParams = 'https://storage.example.com/question-figures/E9B05.png?t=1234567890';
-      mockSelect.mockResolvedValueOnce({
+      mockRange.mockResolvedValueOnce({
         data: [
           { id: 'uuid-e9b05', display_name: 'E9B05', question: 'Q?', options: ['A', 'B', 'C', 'D'], correct_answer: 0, subelement: 'E9', question_group: 'E9B', links: [], explanation: null, forum_url: null, figure_url: urlWithParams },
         ],
@@ -436,7 +437,7 @@ describe('useQuestions', () => {
 describe('useQuestion', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockSelect.mockResolvedValue({ data: mockDbQuestions, error: null });
+    mockRange.mockResolvedValue({ data: mockDbQuestions, error: null });
   });
 
   // Helper to first load questions into cache, then test useQuestion

--- a/src/hooks/useQuestions.ts
+++ b/src/hooks/useQuestions.ts
@@ -120,7 +120,8 @@ export function useQuestions(testType?: TestType) {
           topic_questions(
             topic:topics(id, slug, title, is_published)
           )
-        `);
+        `)
+        .range(0, 1999); // Bypass Supabase's default 1000 row limit
 
       if (error) throw error;
       let questions = (data as DbQuestion[]).map(transformQuestion);


### PR DESCRIPTION
## Summary
- Fixes topic question manager only showing 1000 of 1440 questions
- Fixes filters/search not working for Technician questions in topic linking
- Adds `.range(0, 1999)` to queries fetching all questions to bypass Supabase's default 1000 row limit

## Problem
Supabase's PostgREST has a default row limit of 1000. This caused:
1. **Topic Question Manager** showing only 1000 questions when there are 1440
2. **Technician filter not working** - questions are sorted alphabetically (E→G→T), so Technician questions (starting with T) were cut off after the 1000 row limit

## Changes
- `TopicQuestionManager.tsx`: Added `.range(0, 1999)` to fetch all questions for topic linking
- `useQuestions.ts`: Added `.range(0, 1999)` to main questions hook
- Updated test mocks to match new query chain

## Test plan
- [ ] Open topic editor → Questions tab → verify all 1440 questions appear
- [ ] Filter by Technician → verify ~411 questions show
- [ ] Filter by General → verify ~429 questions show  
- [ ] Filter by Extra → verify ~600 questions show
- [ ] Search works across all question types
- [ ] Run `npm run test:run` - all 2329 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)