### PR TITLE
fix(bookmarks): filter bookmark count by selected license level

### DIFF
--- a/src/components/AppLayout.test.tsx
+++ b/src/components/AppLayout.test.tsx
@@ -23,7 +23,10 @@ vi.mock('@/hooks/useAuth', () => ({
 
 vi.mock('@/hooks/useBookmarks', () => ({
   useBookmarks: () => ({
-    bookmarks: [{ question_id: 'T1A01' }, { question_id: 'T1A02' }],
+    bookmarks: [
+      { question_id: 'T1A01', display_name: 'T1A01' },
+      { question_id: 'T1A02', display_name: 'T1A02' },
+    ],
     isLoading: false,
   }),
 }));

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -70,6 +70,13 @@ export function AppLayout({ children, currentView, onViewChange, selectedTest, o
     ? calculateWeakQuestionIds(filteredAttempts)
     : [];
 
+  // Filter bookmarks by selected test type
+  const filteredBookmarks = filterByTestType(
+    bookmarks || [],
+    selectedTest,
+    (b) => b.display_name
+  );
+
   const handleSignOut = async () => {
     // Navigate first to ensure we redirect before state changes trigger re-renders
     navigate('/auth');
@@ -111,7 +118,7 @@ export function AppLayout({ children, currentView, onViewChange, selectedTest, o
           isCollapsed={sidebarCollapsed}
           onToggleCollapse={() => setSidebarCollapsed(!sidebarCollapsed)}
           weakQuestionCount={weakQuestionIds.length}
-          bookmarkCount={bookmarks?.length || 0}
+          bookmarkCount={filteredBookmarks.length}
           isTestAvailable={isTestAvailable}
           userInfo={userInfo}
           userId={user.id}

--- a/src/hooks/useBookmarks.ts
+++ b/src/hooks/useBookmarks.ts
@@ -14,12 +14,16 @@ export function useBookmarks() {
     queryFn: async () => {
       const { data, error } = await supabase
         .from('bookmarked_questions')
-        .select('*')
+        .select('*, questions!inner(display_name)')
         .eq('user_id', user!.id)
         .order('created_at', { ascending: false });
-      
+
       if (error) throw error;
-      return data;
+      // Flatten the joined data to include display_name at the top level
+      return data?.map(bookmark => ({
+        ...bookmark,
+        display_name: bookmark.questions?.display_name
+      })) || [];
     },
     enabled: !!user,
     staleTime: 1000 * 60 * 2, // Cache for 2 minutes


### PR DESCRIPTION
## Summary
- Fixed mismatch between sidebar bookmark badge count and displayed bookmarks
- Sidebar now shows only bookmarks for the currently selected license level (Technician/General/Extra)
- Applied the same fix pattern used for weak questions filtering

## Test plan
- [ ] Navigate to bookmarks with bookmarks saved for different license levels
- [ ] Verify badge count updates when switching between Technician/General/Extra
- [ ] Verify badge count matches the number of bookmarks shown in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)