### PR TITLE
feat(pwa): add non-intrusive PWA install prompt

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { PostHogProvider } from "@/hooks/usePostHog";
 import { PendoProvider } from "@/hooks/usePendo";
 import { AppNavigationProvider } from "@/hooks/useAppNavigation";
 import { ThemeProvider } from "next-themes";
+import { PWAInstallBanner } from "@/components/PWAInstallBanner";
 
 // Lazy load pages for code splitting
 const Index = lazy(() => import("./pages/Index"));
@@ -41,6 +42,7 @@ const App = () => (
               <TooltipProvider>
                 <Toaster />
                 <Sonner />
+                <PWAInstallBanner />
                 <BrowserRouter>
                   <Suspense fallback={<PageLoader />}>
                     <Routes>

--- a/src/components/PWAInstallBanner.test.tsx
+++ b/src/components/PWAInstallBanner.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PWAInstallBanner } from './PWAInstallBanner';
+
+// Mock the usePWAInstall hook
+const mockTriggerInstall = vi.fn();
+const mockDismissPrompt = vi.fn();
+
+vi.mock('@/hooks/usePWAInstall', () => ({
+  usePWAInstall: vi.fn(() => ({
+    showPrompt: true,
+    isIOS: false,
+    triggerInstall: mockTriggerInstall,
+    dismissPrompt: mockDismissPrompt,
+  })),
+}));
+
+// Import after mocking
+import { usePWAInstall } from '@/hooks/usePWAInstall';
+
+describe('PWAInstallBanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should not render when showPrompt is false', () => {
+    vi.mocked(usePWAInstall).mockReturnValue({
+      showPrompt: false,
+      isIOS: false,
+      canInstall: false,
+      isInstalled: false,
+      triggerInstall: mockTriggerInstall,
+      dismissPrompt: mockDismissPrompt,
+    });
+
+    render(<PWAInstallBanner />);
+
+    expect(screen.queryByText('Install Open Ham Prep')).not.toBeInTheDocument();
+  });
+
+  it('should render banner when showPrompt is true', () => {
+    vi.mocked(usePWAInstall).mockReturnValue({
+      showPrompt: true,
+      isIOS: false,
+      canInstall: true,
+      isInstalled: false,
+      triggerInstall: mockTriggerInstall,
+      dismissPrompt: mockDismissPrompt,
+    });
+
+    render(<PWAInstallBanner />);
+
+    expect(screen.getByText('Install Open Ham Prep')).toBeInTheDocument();
+    expect(
+      screen.getByText('Quick access from your home screen')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Install' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Not now' })
+    ).toBeInTheDocument();
+  });
+
+  it('should have proper accessibility attributes', () => {
+    vi.mocked(usePWAInstall).mockReturnValue({
+      showPrompt: true,
+      isIOS: false,
+      canInstall: true,
+      isInstalled: false,
+      triggerInstall: mockTriggerInstall,
+      dismissPrompt: mockDismissPrompt,
+    });
+
+    render(<PWAInstallBanner />);
+
+    const banner = screen.getByRole('alertdialog');
+    expect(banner).toHaveAttribute('aria-labelledby', 'pwa-install-title');
+    expect(banner).toHaveAttribute(
+      'aria-describedby',
+      'pwa-install-description'
+    );
+  });
+
+  it('should call triggerInstall when Install button is clicked', () => {
+    vi.mocked(usePWAInstall).mockReturnValue({
+      showPrompt: true,
+      isIOS: false,
+      canInstall: true,
+      isInstalled: false,
+      triggerInstall: mockTriggerInstall,
+      dismissPrompt: mockDismissPrompt,
+    });
+
+    render(<PWAInstallBanner />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Install' }));
+
+    expect(mockTriggerInstall).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call dismissPrompt when Not now button is clicked', () => {
+    vi.mocked(usePWAInstall).mockReturnValue({
+      showPrompt: true,
+      isIOS: false,
+      canInstall: true,
+      isInstalled: false,
+      triggerInstall: mockTriggerInstall,
+      dismissPrompt: mockDismissPrompt,
+    });
+
+    render(<PWAInstallBanner />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Not now' }));
+
+    expect(mockDismissPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call dismissPrompt when X button is clicked', () => {
+    vi.mocked(usePWAInstall).mockReturnValue({
+      showPrompt: true,
+      isIOS: false,
+      canInstall: true,
+      isInstalled: false,
+      triggerInstall: mockTriggerInstall,
+      dismissPrompt: mockDismissPrompt,
+    });
+
+    render(<PWAInstallBanner />);
+
+    fireEvent.click(screen.getByLabelText('Dismiss install prompt'));
+
+    expect(mockDismissPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call dismissPrompt when Escape key is pressed', () => {
+    vi.mocked(usePWAInstall).mockReturnValue({
+      showPrompt: true,
+      isIOS: false,
+      canInstall: true,
+      isInstalled: false,
+      triggerInstall: mockTriggerInstall,
+      dismissPrompt: mockDismissPrompt,
+    });
+
+    render(<PWAInstallBanner />);
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(mockDismissPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('should render iOS dialog when isIOS is true', () => {
+    vi.mocked(usePWAInstall).mockReturnValue({
+      showPrompt: true,
+      isIOS: true,
+      canInstall: true,
+      isInstalled: false,
+      triggerInstall: mockTriggerInstall,
+      dismissPrompt: mockDismissPrompt,
+    });
+
+    render(<PWAInstallBanner />);
+
+    // iOS dialog has step-by-step instructions
+    expect(screen.getByText(/Tap the/)).toBeInTheDocument();
+    expect(screen.getByText(/button in Safari/)).toBeInTheDocument();
+    expect(screen.getByText(/Scroll down and tap/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Got it' })).toBeInTheDocument();
+  });
+
+  it('should call dismissPrompt when Got it button is clicked in iOS dialog', () => {
+    vi.mocked(usePWAInstall).mockReturnValue({
+      showPrompt: true,
+      isIOS: true,
+      canInstall: true,
+      isInstalled: false,
+      triggerInstall: mockTriggerInstall,
+      dismissPrompt: mockDismissPrompt,
+    });
+
+    render(<PWAInstallBanner />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Got it' }));
+
+    expect(mockDismissPrompt).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/PWAInstallBanner.tsx
+++ b/src/components/PWAInstallBanner.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useCallback, useRef } from 'react';
+import { usePWAInstall } from '@/hooks/usePWAInstall';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Download, X, Share, Plus } from 'lucide-react';
+
+export function PWAInstallBanner() {
+  const { showPrompt, isIOS, triggerInstall, dismissPrompt } = usePWAInstall();
+  const bannerRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  // Handle Escape key to dismiss
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && showPrompt) {
+        dismissPrompt();
+      }
+    },
+    [showPrompt, dismissPrompt]
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+
+  // Focus management: move focus to banner when it appears, restore when dismissed
+  useEffect(() => {
+    if (showPrompt && bannerRef.current && !isIOS) {
+      previousFocusRef.current = document.activeElement as HTMLElement;
+      // Small delay to ensure animation has started
+      const timer = setTimeout(() => {
+        bannerRef.current?.focus();
+      }, 100);
+      return () => clearTimeout(timer);
+    }
+  }, [showPrompt, isIOS]);
+
+  // Restore focus when banner is dismissed
+  useEffect(() => {
+    return () => {
+      if (previousFocusRef.current && typeof previousFocusRef.current.focus === 'function') {
+        previousFocusRef.current.focus();
+      }
+    };
+  }, []);
+
+  if (!showPrompt) return null;
+
+  // iOS needs manual instructions via dialog
+  if (isIOS) {
+    return <IOSInstallDialog onDismiss={dismissPrompt} />;
+  }
+
+  // Standard install banner for Chrome, Edge, etc.
+  return (
+    <div
+      ref={bannerRef}
+      tabIndex={-1}
+      className="fixed bottom-20 left-4 right-4 sm:left-auto sm:right-4 sm:max-w-sm z-40
+                 bg-card border border-border rounded-lg shadow-lg p-4
+                 animate-in slide-in-from-bottom-4 fade-in duration-300
+                 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+      role="alertdialog"
+      aria-labelledby="pwa-install-title"
+      aria-describedby="pwa-install-description"
+      aria-modal="false"
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex-shrink-0 w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center">
+          <Download className="w-5 h-5 text-primary" aria-hidden="true" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3
+            id="pwa-install-title"
+            className="font-medium text-foreground text-sm"
+          >
+            Install Open Ham Prep
+          </h3>
+          <p
+            id="pwa-install-description"
+            className="text-sm text-muted-foreground mt-0.5"
+          >
+            Quick access from your home screen
+          </p>
+        </div>
+        <button
+          onClick={dismissPrompt}
+          className="flex-shrink-0 p-1 text-muted-foreground hover:text-foreground rounded transition-colors"
+          aria-label="Dismiss install prompt"
+        >
+          <X className="w-4 h-4" aria-hidden="true" />
+        </button>
+      </div>
+      <div className="flex gap-2 mt-3 justify-end">
+        <Button variant="ghost" size="sm" onClick={dismissPrompt}>
+          Not now
+        </Button>
+        <Button size="sm" onClick={triggerInstall}>
+          Install
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+interface IOSInstallDialogProps {
+  onDismiss: () => void;
+}
+
+function IOSInstallDialog({ onDismiss }: IOSInstallDialogProps) {
+  return (
+    <Dialog open onOpenChange={(open) => !open && onDismiss()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Download className="w-5 h-5 text-primary" aria-hidden="true" />
+            Install Open Ham Prep
+          </DialogTitle>
+          <DialogDescription>
+            Add this app to your home screen for quick access
+          </DialogDescription>
+        </DialogHeader>
+
+        <ol className="space-y-4 py-4 list-none" aria-label="Installation steps">
+          <li className="flex items-start gap-3">
+            <div className="flex-shrink-0 w-8 h-8 rounded-full bg-muted flex items-center justify-center text-sm font-medium" aria-hidden="true">
+              1
+            </div>
+            <div className="flex-1">
+              <p className="text-sm text-foreground">
+                Tap the{' '}
+                <span className="inline-flex items-center gap-1 font-medium">
+                  Share
+                  <Share className="w-4 h-4" aria-hidden="true" />
+                </span>{' '}
+                button in Safari
+              </p>
+            </div>
+          </li>
+
+          <li className="flex items-start gap-3">
+            <div className="flex-shrink-0 w-8 h-8 rounded-full bg-muted flex items-center justify-center text-sm font-medium" aria-hidden="true">
+              2
+            </div>
+            <div className="flex-1">
+              <p className="text-sm text-foreground">
+                Scroll down and tap{' '}
+                <span className="inline-flex items-center gap-1 font-medium">
+                  Add to Home Screen
+                  <Plus className="w-4 h-4" aria-hidden="true" />
+                </span>
+              </p>
+            </div>
+          </li>
+
+          <li className="flex items-start gap-3">
+            <div className="flex-shrink-0 w-8 h-8 rounded-full bg-muted flex items-center justify-center text-sm font-medium" aria-hidden="true">
+              3
+            </div>
+            <div className="flex-1">
+              <p className="text-sm text-foreground">
+                Tap <span className="font-medium">Add</span> to confirm
+              </p>
+            </div>
+          </li>
+        </ol>
+
+        <div className="flex justify-end">
+          <Button variant="ghost" onClick={onDismiss}>
+            Got it
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/hooks/usePWAInstall.test.ts
+++ b/src/hooks/usePWAInstall.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePWAInstall } from './usePWAInstall';
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] || null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+    get store() {
+      return store;
+    },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+});
+
+// Mock matchMedia
+const mockMatchMedia = vi.fn();
+Object.defineProperty(window, 'matchMedia', {
+  value: mockMatchMedia,
+});
+
+describe('usePWAInstall', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorageMock.clear();
+
+    // Default matchMedia mock - not in standalone mode
+    mockMatchMedia.mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('should start with showPrompt false before engagement delay', () => {
+    const { result } = renderHook(() => usePWAInstall());
+
+    expect(result.current.showPrompt).toBe(false);
+    expect(result.current.hasEngaged).toBeUndefined(); // Internal state, exposed via showPrompt
+  });
+
+  it('should detect when already installed in standalone mode', () => {
+    mockMatchMedia.mockReturnValue({
+      matches: true, // Standalone mode
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+
+    const { result } = renderHook(() => usePWAInstall());
+
+    expect(result.current.isInstalled).toBe(true);
+    expect(result.current.canInstall).toBe(false);
+  });
+
+  it('should capture beforeinstallprompt event', () => {
+    const { result } = renderHook(() => usePWAInstall());
+
+    // Initially canInstall is false (no event yet)
+    expect(result.current.canInstall).toBe(false);
+
+    // Simulate beforeinstallprompt event
+    const mockPrompt = vi.fn().mockResolvedValue(undefined);
+    const mockEvent = {
+      preventDefault: vi.fn(),
+      prompt: mockPrompt,
+      userChoice: Promise.resolve({ outcome: 'accepted' }),
+    };
+
+    act(() => {
+      window.dispatchEvent(
+        Object.assign(new Event('beforeinstallprompt'), mockEvent)
+      );
+    });
+
+    expect(mockEvent.preventDefault).toHaveBeenCalled();
+    expect(result.current.canInstall).toBe(true);
+  });
+
+  it('should show prompt after engagement delay when event is captured', () => {
+    const { result } = renderHook(() => usePWAInstall());
+
+    // Simulate beforeinstallprompt event
+    const mockEvent = {
+      preventDefault: vi.fn(),
+      prompt: vi.fn().mockResolvedValue(undefined),
+      userChoice: Promise.resolve({ outcome: 'accepted' }),
+    };
+
+    act(() => {
+      window.dispatchEvent(
+        Object.assign(new Event('beforeinstallprompt'), mockEvent)
+      );
+    });
+
+    expect(result.current.showPrompt).toBe(false);
+
+    // Fast-forward past engagement delay (30 seconds)
+    act(() => {
+      vi.advanceTimersByTime(30000);
+    });
+
+    expect(result.current.showPrompt).toBe(true);
+  });
+
+  it('should not show prompt if user previously dismissed', () => {
+    // Set up dismissed state in localStorage
+    localStorageMock.setItem('pwa_install_dismissed', 'true');
+
+    const { result } = renderHook(() => usePWAInstall());
+
+    // Simulate beforeinstallprompt event
+    const mockEvent = {
+      preventDefault: vi.fn(),
+      prompt: vi.fn().mockResolvedValue(undefined),
+      userChoice: Promise.resolve({ outcome: 'accepted' }),
+    };
+
+    act(() => {
+      window.dispatchEvent(
+        Object.assign(new Event('beforeinstallprompt'), mockEvent)
+      );
+    });
+
+    // Fast-forward past engagement delay
+    act(() => {
+      vi.advanceTimersByTime(30000);
+    });
+
+    expect(result.current.showPrompt).toBe(false);
+    expect(result.current.canInstall).toBe(false);
+  });
+
+  it('should save dismissal to localStorage when dismissPrompt is called', () => {
+    const { result } = renderHook(() => usePWAInstall());
+
+    // Simulate beforeinstallprompt event
+    const mockEvent = {
+      preventDefault: vi.fn(),
+      prompt: vi.fn().mockResolvedValue(undefined),
+      userChoice: Promise.resolve({ outcome: 'accepted' }),
+    };
+
+    act(() => {
+      window.dispatchEvent(
+        Object.assign(new Event('beforeinstallprompt'), mockEvent)
+      );
+    });
+
+    act(() => {
+      result.current.dismissPrompt();
+    });
+
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      'pwa_install_dismissed',
+      'true'
+    );
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      'pwa_install_outcome',
+      'dismissed'
+    );
+    expect(result.current.canInstall).toBe(false);
+  });
+
+  it('should call native prompt when triggerInstall is called', async () => {
+    const { result } = renderHook(() => usePWAInstall());
+
+    const mockPrompt = vi.fn().mockResolvedValue(undefined);
+    const mockEvent = {
+      preventDefault: vi.fn(),
+      prompt: mockPrompt,
+      userChoice: Promise.resolve({ outcome: 'accepted' }),
+    };
+
+    act(() => {
+      window.dispatchEvent(
+        Object.assign(new Event('beforeinstallprompt'), mockEvent)
+      );
+    });
+
+    await act(async () => {
+      await result.current.triggerInstall();
+    });
+
+    expect(mockPrompt).toHaveBeenCalled();
+  });
+
+  it('should save accepted outcome when user accepts install', async () => {
+    const { result } = renderHook(() => usePWAInstall());
+
+    const mockEvent = {
+      preventDefault: vi.fn(),
+      prompt: vi.fn().mockResolvedValue(undefined),
+      userChoice: Promise.resolve({ outcome: 'accepted' as const }),
+    };
+
+    act(() => {
+      window.dispatchEvent(
+        Object.assign(new Event('beforeinstallprompt'), mockEvent)
+      );
+    });
+
+    await act(async () => {
+      await result.current.triggerInstall();
+    });
+
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      'pwa_install_outcome',
+      'accepted'
+    );
+  });
+
+  it('should save dismissed outcome when user dismisses native prompt', async () => {
+    const { result } = renderHook(() => usePWAInstall());
+
+    const mockEvent = {
+      preventDefault: vi.fn(),
+      prompt: vi.fn().mockResolvedValue(undefined),
+      userChoice: Promise.resolve({ outcome: 'dismissed' as const }),
+    };
+
+    act(() => {
+      window.dispatchEvent(
+        Object.assign(new Event('beforeinstallprompt'), mockEvent)
+      );
+    });
+
+    await act(async () => {
+      await result.current.triggerInstall();
+    });
+
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      'pwa_install_dismissed',
+      'true'
+    );
+  });
+
+  it('should update isInstalled when appinstalled event fires', () => {
+    const { result } = renderHook(() => usePWAInstall());
+
+    expect(result.current.isInstalled).toBe(false);
+
+    act(() => {
+      window.dispatchEvent(new Event('appinstalled'));
+    });
+
+    expect(result.current.isInstalled).toBe(true);
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      'pwa_install_outcome',
+      'accepted'
+    );
+  });
+
+  it('should detect iOS devices', () => {
+    // Save original userAgent
+    const originalUserAgent = navigator.userAgent;
+
+    // Mock iOS user agent
+    Object.defineProperty(navigator, 'userAgent', {
+      value:
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15',
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => usePWAInstall());
+
+    expect(result.current.isIOS).toBe(true);
+
+    // Restore original
+    Object.defineProperty(navigator, 'userAgent', {
+      value: originalUserAgent,
+      configurable: true,
+    });
+  });
+});

--- a/src/hooks/usePWAInstall.ts
+++ b/src/hooks/usePWAInstall.ts
@@ -1,0 +1,160 @@
+import { useState, useEffect, useCallback } from 'react';
+
+const PWA_DISMISSED_KEY = 'pwa_install_dismissed';
+const PWA_OUTCOME_KEY = 'pwa_install_outcome';
+const ENGAGEMENT_DELAY_MS = 30000; // 30 seconds
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+}
+
+interface PWAInstallState {
+  canInstall: boolean;
+  isInstalled: boolean;
+  isIOS: boolean;
+  showPrompt: boolean;
+  triggerInstall: () => Promise<void>;
+  dismissPrompt: () => void;
+}
+
+function isDismissed(): boolean {
+  try {
+    return localStorage.getItem(PWA_DISMISSED_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function saveDismissal(): void {
+  try {
+    localStorage.setItem(PWA_DISMISSED_KEY, 'true');
+    localStorage.setItem(PWA_OUTCOME_KEY, 'dismissed');
+  } catch {
+    // localStorage not available
+  }
+}
+
+function saveAccepted(): void {
+  try {
+    localStorage.setItem(PWA_OUTCOME_KEY, 'accepted');
+  } catch {
+    // localStorage not available
+  }
+}
+
+function detectIOS(): boolean {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+    return false;
+  }
+  const userAgent = navigator.userAgent || navigator.vendor || '';
+  // MSStream check is for IE11 detection on Windows Phone
+  const windowWithMSStream = window as Window & { MSStream?: unknown };
+  return /iPad|iPhone|iPod/.test(userAgent) && !windowWithMSStream.MSStream;
+}
+
+function isStandalone(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  // Safari on iOS has a standalone property on navigator
+  const navigatorWithStandalone = navigator as Navigator & { standalone?: boolean };
+  return (
+    window.matchMedia('(display-mode: standalone)').matches ||
+    navigatorWithStandalone.standalone === true
+  );
+}
+
+export function usePWAInstall(): PWAInstallState {
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  const [isInstalled, setIsInstalled] = useState(false);
+  const [hasEngaged, setHasEngaged] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+  const [isIOS] = useState(detectIOS);
+
+  // Check if already installed (standalone mode)
+  useEffect(() => {
+    setIsInstalled(isStandalone());
+
+    // Listen for display mode changes
+    const mediaQuery = window.matchMedia('(display-mode: standalone)');
+    const handler = (e: MediaQueryListEvent) => setIsInstalled(e.matches);
+    mediaQuery.addEventListener('change', handler);
+    return () => mediaQuery.removeEventListener('change', handler);
+  }, []);
+
+  // Check if user permanently dismissed
+  useEffect(() => {
+    setDismissed(isDismissed());
+  }, []);
+
+  // Capture beforeinstallprompt event
+  useEffect(() => {
+    const handler = (e: Event) => {
+      e.preventDefault(); // Prevent Chrome's mini-infobar
+      setDeferredPrompt(e as BeforeInstallPromptEvent);
+    };
+
+    window.addEventListener('beforeinstallprompt', handler);
+    return () => window.removeEventListener('beforeinstallprompt', handler);
+  }, []);
+
+  // Listen for successful installation
+  useEffect(() => {
+    const handler = () => {
+      setIsInstalled(true);
+      setDeferredPrompt(null);
+      saveAccepted();
+    };
+
+    window.addEventListener('appinstalled', handler);
+    return () => window.removeEventListener('appinstalled', handler);
+  }, []);
+
+  // Engagement timer - wait before showing prompt
+  useEffect(() => {
+    const timer = setTimeout(() => setHasEngaged(true), ENGAGEMENT_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const triggerInstall = useCallback(async () => {
+    if (!deferredPrompt) return;
+
+    try {
+      await deferredPrompt.prompt();
+      const { outcome } = await deferredPrompt.userChoice;
+
+      if (outcome === 'accepted') {
+        saveAccepted();
+      } else {
+        saveDismissal();
+        setDismissed(true);
+      }
+    } catch (error) {
+      console.warn('PWA install prompt failed:', error);
+    } finally {
+      setDeferredPrompt(null);
+    }
+  }, [deferredPrompt]);
+
+  const dismissPrompt = useCallback(() => {
+    saveDismissal();
+    setDismissed(true);
+    setDeferredPrompt(null);
+  }, []);
+
+  // Determine if we can show the install option
+  const canInstall = (!!deferredPrompt || isIOS) && !isInstalled && !dismissed;
+
+  // Only show after engagement delay
+  const showPrompt = canInstall && hasEngaged;
+
+  return {
+    canInstall,
+    isInstalled,
+    isIOS,
+    showPrompt,
+    triggerInstall,
+    dismissPrompt,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a compliant PWA install prompt that appears after 30 seconds of user engagement
- Permanently dismisses if user clicks "Not now" (respects user choice)
- Uses `beforeinstallprompt` event properly to trigger native install flow
- Provides iOS fallback with step-by-step Safari "Add to Home Screen" instructions

## Accessibility
- `role="alertdialog"` with proper `aria-labelledby`/`aria-describedby`
- Focus management: moves focus to banner when shown, restores on dismiss
- Escape key dismissal
- Semantic `<ol>` list for iOS installation steps
- Focus-visible ring styling for keyboard users

## Test plan
- [ ] Verify banner appears after 30 seconds on Chrome/Edge (desktop)
- [ ] Click "Install" and verify native install prompt appears
- [ ] Click "Not now" and verify banner never appears again (check localStorage)
- [ ] Test Escape key dismisses the banner
- [ ] Test on iOS Safari - verify dialog with manual instructions appears
- [ ] Verify screen reader announces the banner correctly
- [ ] Run `npm run test:run` - all 20 new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)