### PR TITLE
feat: add DuckDuckGo search on glossary term click

### DIFF
--- a/src/components/Glossary.tsx
+++ b/src/components/Glossary.tsx
@@ -99,8 +99,17 @@ export function Glossary() {
                   {groupedTerms[letter].map(term => (
                     <Card
                       key={term.id}
-                      className="bg-card/50 border-border/50 hover:border-primary/30 transition-colors cursor-pointer"
-                      onClick={() => window.open(`https://duckduckgo.com/?q=${encodeURIComponent(term.term)}&kp=1`, '_blank')}
+                      className="bg-card/50 border-border/50 hover:border-primary/30 transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+                      onClick={() => window.open(`https://duckduckgo.com/?q=${encodeURIComponent(term.term)}&kp=1`, '_blank', 'noopener,noreferrer')}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          window.open(`https://duckduckgo.com/?q=${encodeURIComponent(term.term)}&kp=1`, '_blank', 'noopener,noreferrer');
+                        }
+                      }}
+                      tabIndex={0}
+                      role="button"
+                      aria-label={`Search "${term.term}" on DuckDuckGo`}
                     >
                       <CardContent className="py-3 px-4">
                         <h3 className="font-semibold text-foreground text-lg">{term.term}</h3>


### PR DESCRIPTION
## Summary
- Clicking a glossary term card now opens a DuckDuckGo search in a new tab
- Safe search is enabled via the `kp=1` URL parameter
- Added `cursor-pointer` class for visual feedback that cards are clickable

## Test plan
- [ ] Navigate to the Glossary page
- [ ] Click on any glossary term card
- [ ] Verify a new tab opens with DuckDuckGo search results for that term
- [ ] Verify safe search is active (check URL contains `kp=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)