### PR TITLE
Fix minor bugs, improve accessibility, and update data refresh

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,30 +42,43 @@
         align-items: center;
         justify-content: center;
         min-height: 100vh;
-        background: #0a0a0a;
+      }
+      /* Light mode loading state */
+      #root:empty {
+        background: #ffffff;
       }
       #root:empty::before {
         content: "";
         width: 40px;
         height: 40px;
-        border: 3px solid #1a1a1a;
+        border: 3px solid #e5e5e5;
         border-top-color: #b86800;
         border-radius: 50%;
         animation: spin 1s linear infinite;
       }
+      /* Dark mode loading state */
+      html.dark #root:empty {
+        background: #0a0a0a;
+      }
+      html.dark #root:empty::before {
+        border-color: #1a1a1a;
+        border-top-color: #b86800;
+      }
       @keyframes spin {
         to { transform: rotate(360deg); }
       }
-      @media (prefers-color-scheme: light) {
-        #root:empty {
-          background: #ffffff;
-        }
-        #root:empty::before {
-          border-color: #e5e5e5;
-          border-top-color: #b86800;
-        }
-      }
     </style>
+    <!-- Prevent theme flash by setting theme class before React loads -->
+    <script>
+      (function() {
+        try {
+          var theme = localStorage.getItem('theme');
+          if (theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+            document.documentElement.classList.add('dark');
+          }
+        } catch (e) {}
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Calculator.test.tsx
+++ b/src/components/Calculator.test.tsx
@@ -119,7 +119,7 @@ describe('Calculator', () => {
 
       await user.click(screen.getByRole('button', { name: /open calculator/i }));
       await user.click(screen.getByRole('button', { name: '1' }));
-      await user.click(screen.getByRole('button', { name: '.' }));
+      await user.click(screen.getByRole('button', { name: /decimal point/i }));
       await user.click(screen.getByRole('button', { name: '5' }));
 
       const display = document.querySelector('.font-mono.text-xl');
@@ -132,8 +132,8 @@ describe('Calculator', () => {
 
       await user.click(screen.getByRole('button', { name: /open calculator/i }));
       await user.click(screen.getByRole('button', { name: '1' }));
-      await user.click(screen.getByRole('button', { name: '.' }));
-      await user.click(screen.getByRole('button', { name: '.' }));
+      await user.click(screen.getByRole('button', { name: /decimal point/i }));
+      await user.click(screen.getByRole('button', { name: /decimal point/i }));
       await user.click(screen.getByRole('button', { name: '5' }));
 
       const display = document.querySelector('.font-mono.text-xl');
@@ -150,9 +150,9 @@ describe('Calculator', () => {
 
       // Should be able to click operation buttons without error
       await user.click(screen.getByRole('button', { name: '2' }));
-      await user.click(screen.getByRole('button', { name: '+' }));
+      await user.click(screen.getByRole('button', { name: /add/i }));
       await user.click(screen.getByRole('button', { name: '3' }));
-      await user.click(screen.getByRole('button', { name: '=' }));
+      await user.click(screen.getByRole('button', { name: /equals/i }));
 
       // Calculator should still be open
       expect(screen.getByText('Close')).toBeInTheDocument();
@@ -168,7 +168,7 @@ describe('Calculator', () => {
       await user.click(screen.getByRole('button', { name: '1' }));
       await user.click(screen.getByRole('button', { name: '2' }));
       await user.click(screen.getByRole('button', { name: '3' }));
-      await user.click(screen.getByRole('button', { name: 'C' }));
+      await user.click(screen.getByRole('button', { name: /clear/i }));
 
       // The display shows 0 after clear
       const display = document.querySelector('.font-mono.text-xl');
@@ -194,12 +194,12 @@ describe('Calculator', () => {
 
       await user.click(screen.getByRole('button', { name: /open calculator/i }));
 
-      expect(screen.getByRole('button', { name: '+' })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: '-' })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: '×' })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: '÷' })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: '=' })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'C' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /add/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /subtract/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /multiply/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /divide/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /equals/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /clear/i })).toBeInTheDocument();
     });
 
     it('displays decimal button', async () => {
@@ -208,7 +208,7 @@ describe('Calculator', () => {
 
       await user.click(screen.getByRole('button', { name: /open calculator/i }));
 
-      expect(screen.getByRole('button', { name: '.' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /decimal point/i })).toBeInTheDocument();
     });
   });
 

--- a/src/components/Calculator.tsx
+++ b/src/components/Calculator.tsx
@@ -123,6 +123,17 @@ export function Calculator({ className }: CalculatorProps) {
     ["0", ".", "="],
   ];
 
+  // Accessible labels for operator buttons
+  const buttonLabels: Record<string, string> = {
+    "C": "Clear",
+    "÷": "Divide",
+    "×": "Multiply",
+    "-": "Subtract",
+    "+": "Add",
+    "=": "Equals",
+    ".": "Decimal point",
+  };
+
   const handleButtonClick = useCallback((btn: string) => {
     if (btn === "C") {
       clear();
@@ -197,7 +208,12 @@ export function Calculator({ className }: CalculatorProps) {
             <span className="text-xs font-medium text-muted-foreground">Calculator</span>
           </div>
 
-          <div className="bg-secondary rounded-md p-3 mb-2 text-right">
+          <div
+            className="bg-secondary rounded-md p-3 mb-2 text-right"
+            role="status"
+            aria-live="polite"
+            aria-label="Calculator display"
+          >
             <span className="font-mono text-xl text-foreground">
               {display.length > 12 ? parseFloat(display).toExponential(6) : display}
             </span>
@@ -217,6 +233,7 @@ export function Calculator({ className }: CalculatorProps) {
                       btn === "C" && "col-span-3"
                     )}
                     onClick={() => handleButtonClick(btn)}
+                    aria-label={buttonLabels[btn] || btn}
                   >
                     {btn}
                   </Button>

--- a/src/components/GlossaryHighlightedText.tsx
+++ b/src/components/GlossaryHighlightedText.tsx
@@ -80,7 +80,12 @@ export function GlossaryHighlightedText({ text }: GlossaryHighlightedTextProps) 
             return (
               <Tooltip key={index}>
                 <TooltipTrigger asChild>
-                  <span className="underline decoration-primary/50 decoration-dotted underline-offset-2 cursor-help text-primary/90 hover:text-primary hover:decoration-primary transition-colors">
+                  <span
+                    className="underline decoration-primary/50 decoration-dotted underline-offset-2 cursor-help text-primary/90 hover:text-primary hover:decoration-primary transition-colors"
+                    role="button"
+                    tabIndex={0}
+                    aria-label={`${segment.term.term}: ${segment.term.definition.slice(0, 50)}${segment.term.definition.length > 50 ? '...' : ''}`}
+                  >
                     {segment.text}
                   </span>
                 </TooltipTrigger>

--- a/src/components/LessonCard.tsx
+++ b/src/components/LessonCard.tsx
@@ -18,13 +18,25 @@ interface LessonCardProps {
 export function LessonCard({ lesson, completion, onClick }: LessonCardProps) {
   const isComplete = completion.percentage === 100;
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onClick();
+    }
+  };
+
   return (
     <Card
       className={cn(
         "cursor-pointer transition-all hover:shadow-lg hover:scale-[1.02] group overflow-hidden",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
         isComplete && "ring-2 ring-success/50"
       )}
       onClick={onClick}
+      onKeyDown={handleKeyDown}
+      role="button"
+      tabIndex={0}
+      aria-label={`${lesson.title}, ${completion.percentage}% complete${isComplete ? ' (completed)' : ''}`}
     >
       {/* Thumbnail */}
       <div className="relative aspect-video bg-muted overflow-hidden">

--- a/src/components/LinkPreview.tsx
+++ b/src/components/LinkPreview.tsx
@@ -13,14 +13,18 @@ export function LinkPreview({ link }: LinkPreviewProps) {
   const typeLabel = config?.label ?? "Link";
   const typeColor = config ? `${config.colorClass} ${config.bgClass}` : "text-muted-foreground bg-secondary";
 
+  const linkTitle = link.title || link.url;
+
   return (
     <a
       href={link.url}
       target="_blank"
       rel="noopener noreferrer"
+      aria-label={`${linkTitle} (opens in new tab)`}
       className={cn(
         "flex gap-4 p-4 rounded-lg border border-border bg-card/50",
         "hover:bg-secondary/50 hover:border-primary/30 transition-all duration-200",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
         "group"
       )}
     >
@@ -43,7 +47,7 @@ export function LinkPreview({ link }: LinkPreviewProps) {
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 mb-1">
           <span className={cn("inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium", typeColor)}>
-            <TypeIcon className="w-3 h-3" />
+            <TypeIcon className="w-3 h-3" aria-hidden="true" />
             {typeLabel}
           </span>
           {link.siteName && (
@@ -64,7 +68,7 @@ export function LinkPreview({ link }: LinkPreviewProps) {
         )}
       </div>
       
-      <ExternalLink className="flex-shrink-0 w-4 h-4 text-muted-foreground group-hover:text-primary transition-colors mt-1" />
+      <ExternalLink className="flex-shrink-0 w-4 h-4 text-muted-foreground group-hover:text-primary transition-colors mt-1" aria-hidden="true" />
     </a>
   );
 }

--- a/src/components/ProfileModal.tsx
+++ b/src/components/ProfileModal.tsx
@@ -546,8 +546,8 @@ export function ProfileModal({
     </div>
   );
 
-  // Danger zone view
-  const DangerView = () => (
+  // Danger zone view - extracted as inline JSX to avoid focus loss from function recreation
+  const dangerViewContent = (
     <div className="space-y-4">
       <div className="p-4 rounded-xl bg-destructive/5 border border-destructive/20 space-y-4">
         <div className="flex items-start gap-3">
@@ -644,7 +644,7 @@ export function ProfileModal({
           {currentView === "main" && <MainView />}
           {currentView === "account" && <AccountView />}
           {currentView === "appearance" && <AppearanceView />}
-          {currentView === "danger" && <DangerView />}
+          {currentView === "danger" && dangerViewContent}
         </div>
       </DialogContent>
     </Dialog>

--- a/src/components/TopicCard.tsx
+++ b/src/components/TopicCard.tsx
@@ -11,13 +11,25 @@ interface TopicCardProps {
 }
 
 export function TopicCard({ topic, isCompleted = false, onClick }: TopicCardProps) {
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onClick();
+    }
+  };
+
   return (
     <Card
       className={cn(
         "cursor-pointer transition-all hover:shadow-lg hover:scale-[1.02] group overflow-hidden",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
         isCompleted && "ring-2 ring-success/50"
       )}
       onClick={onClick}
+      onKeyDown={handleKeyDown}
+      role="button"
+      tabIndex={0}
+      aria-label={`${topic.title}${isCompleted ? ' (completed)' : ''}`}
     >
       {/* Thumbnail */}
       <div className="relative aspect-video bg-muted overflow-hidden">

--- a/src/hooks/useReadinessScore.ts
+++ b/src/hooks/useReadinessScore.ts
@@ -70,7 +70,8 @@ export function useReadinessScore(examType: TestType) {
       return data as ReadinessData | null;
     },
     enabled: !!user,
-    staleTime: 5 * 60 * 1000, // 5 minutes - edge function updates on events
+    staleTime: 30 * 1000, // 30 seconds - allow more frequent refetches after invalidation
+    gcTime: 5 * 60 * 1000, // 5 minutes - keep in cache for background updates
   });
 }
 

--- a/src/hooks/useReadinessSnapshots.ts
+++ b/src/hooks/useReadinessSnapshots.ts
@@ -64,7 +64,8 @@ export function useReadinessSnapshots({
       return (data as ReadinessSnapshot[]) || [];
     },
     enabled: !!user,
-    staleTime: 10 * 60 * 1000, // 10 minutes - snapshots are daily
+    staleTime: 60 * 1000, // 1 minute - allow refetch after test completion
+    gcTime: 10 * 60 * 1000, // 10 minutes - keep in cache for background updates
   });
 }
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -223,7 +223,7 @@ export default function Dashboard() {
   const currentTest = testTypes.find(t => t.id === selectedTest);
   const isTestAvailable = currentTest?.available ?? false;
 
-  // Use test readiness hook for calculations
+  // Use test readiness hook for calculations - use examType for database-backed readiness
   const {
     readinessLevel,
     readinessMessage,
@@ -231,8 +231,9 @@ export default function Dashboard() {
     recentAvgScore,
     nextAction,
   } = useTestReadiness({
-    testResults,
+    examType: selectedTest,
     weakQuestionCount: weakQuestionIds.length,
+    testResults, // Fallback for when DB cache is empty
   });
 
   // Handle view changes with test-in-progress check

--- a/src/pages/QuestionPage.tsx
+++ b/src/pages/QuestionPage.tsx
@@ -21,6 +21,12 @@ export default function QuestionPage() {
   const { navigateToTopic } = useAppNavigation();
   const { data: question, isLoading, error } = useQuestion(id);
 
+  // Handle topic click - navigate to dashboard with topic state
+  const handleTopicClick = (slug: string) => {
+    navigateToTopic(slug);
+    navigate('/dashboard');
+  };
+
   // Update document title - use displayName if available (for UUID-based URLs)
   useEffect(() => {
     const prevTitle = document.title;
@@ -126,7 +132,7 @@ export default function QuestionPage() {
           onSelectAnswer={() => {}}
           showResult={true}
           enableGlossaryHighlight
-          onTopicClick={navigateToTopic}
+          onTopicClick={handleTopicClick}
         />
 
         {/* Sign-up CTA for anonymous users */}

--- a/website/about.html
+++ b/website/about.html
@@ -27,6 +27,17 @@
   <script src="https://unpkg.com/lucide@latest"></script>
 
   <link rel="stylesheet" href="/css/styles.css">
+  <!-- Prevent theme flash by setting theme class before page renders -->
+  <script>
+    (function() {
+      try {
+        var theme = localStorage.getItem('theme');
+        if (theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+          document.documentElement.classList.add('dark');
+        }
+      } catch (e) {}
+    })();
+  </script>
 </head>
 <body class="bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 font-sans antialiased">
   <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/website/css/styles.css
+++ b/website/css/styles.css
@@ -398,6 +398,7 @@ html.dark .feature-card {
   mask-composite: exclude;
   opacity: 0;
   transition: opacity 0.3s ease, background 0.3s ease;
+  pointer-events: none;
 }
 
 .feature-card:hover {

--- a/website/faq.html
+++ b/website/faq.html
@@ -21,6 +21,17 @@
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
   <script src="https://unpkg.com/lucide@latest"></script>
   <link rel="stylesheet" href="/css/styles.css">
+  <!-- Prevent theme flash by setting theme class before page renders -->
+  <script>
+    (function() {
+      try {
+        var theme = localStorage.getItem('theme');
+        if (theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+          document.documentElement.classList.add('dark');
+        }
+      } catch (e) {}
+    })();
+  </script>
 </head>
 <body class="bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 font-sans antialiased">
 
@@ -256,14 +267,14 @@
             </div>
           </div>
 
-          <!-- FAQ Item 10 - Calculator -->
+          <!-- FAQ Item 10 - Community -->
           <div class="faq-item reveal border border-gray-200 dark:border-gray-700 rounded-2xl overflow-hidden" style="transition-delay: 1.0s;">
             <button class="faq-button w-full flex items-center justify-between p-6 text-left bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors" id="faq-btn-10" aria-expanded="false" aria-controls="faq-answer-10">
-              <span class="font-semibold text-lg pr-4">Is there a calculator for math questions?</span>
+              <span class="font-semibold text-lg pr-4">How can I get help or join the community?</span>
               <i data-lucide="chevron-down" aria-hidden="true" class="w-5 h-5 text-amber-600 dark:text-amber-400 flex-shrink-0 transition-transform"></i>
             </button>
             <div id="faq-answer-10" class="faq-answer hidden px-6 pb-6 text-gray-600 dark:text-gray-400">
-              Yes! We have a built-in scientific calculator available during study sessions. Some exam questions involve calculations (like Ohm's Law or frequency calculations), and our calculator is right there when you need it—no switching apps required.
+              Every question has a discussion feature where you can ask questions and get answers from experienced hams. We also have a growing community of users helping each other succeed. Since Open Ham Prep is open source, you can also contribute on GitHub or report issues there.
             </div>
           </div>
         </div>

--- a/website/features.html
+++ b/website/features.html
@@ -21,6 +21,17 @@
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
   <script src="https://unpkg.com/lucide@latest"></script>
   <link rel="stylesheet" href="/css/styles.css">
+  <!-- Prevent theme flash by setting theme class before page renders -->
+  <script>
+    (function() {
+      try {
+        var theme = localStorage.getItem('theme');
+        if (theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+          document.documentElement.classList.add('dark');
+        }
+      } catch (e) {}
+    })();
+  </script>
 </head>
 <body class="bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 font-sans antialiased">
 
@@ -418,11 +429,11 @@
           </div>
 
           <div class="feature-card reveal bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-6 text-center" style="transition-delay: 0.2s;">
-            <div class="w-12 h-12 rounded-xl bg-gray-100 dark:bg-gray-700 flex items-center justify-center mx-auto mb-4">
-              <i data-lucide="calculator" aria-hidden="true" class="w-6 h-6 text-gray-600 dark:text-gray-400"></i>
+            <div class="w-12 h-12 rounded-xl bg-rose-100 dark:bg-rose-900/30 flex items-center justify-center mx-auto mb-4">
+              <i data-lucide="heart" aria-hidden="true" class="w-6 h-6 text-rose-600 dark:text-rose-400"></i>
             </div>
-            <h3 class="font-semibold mb-2">Built-in Calculator</h3>
-            <p class="text-gray-600 dark:text-gray-400 text-sm">Scientific calculator for technical questions. No app switching.</p>
+            <h3 class="font-semibold mb-2">Free Forever</h3>
+            <p class="text-gray-600 dark:text-gray-400 text-sm">100% free, no ads, no subscriptions. Open source and community-driven.</p>
           </div>
 
           <div class="feature-card reveal bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-6 text-center" style="transition-delay: 0.3s;">

--- a/website/index.html
+++ b/website/index.html
@@ -27,6 +27,17 @@
   <script src="https://unpkg.com/lucide@latest"></script>
 
   <link rel="stylesheet" href="/css/styles.css">
+  <!-- Prevent theme flash by setting theme class before page renders -->
+  <script>
+    (function() {
+      try {
+        var theme = localStorage.getItem('theme');
+        if (theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+          document.documentElement.classList.add('dark');
+        }
+      } catch (e) {}
+    })();
+  </script>
 </head>
 <body class="bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 font-sans antialiased">
 
@@ -287,13 +298,13 @@
             <p class="text-gray-600 dark:text-gray-400">Master ham radio terminology with spaced-repetition flashcards. Track which terms you know and which need review.</p>
           </div>
 
-          <!-- Feature: Built-in Calculator -->
+          <!-- Feature: Free Forever -->
           <div class="feature-card reveal bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl p-6" style="transition-delay: 0.6s;">
             <div class="icon-glow w-14 h-14 rounded-xl bg-gray-100 dark:bg-gray-700 flex items-center justify-center mb-5">
-              <i data-lucide="calculator" aria-hidden="true" class="w-7 h-7 text-gray-600 dark:text-gray-400"></i>
+              <i data-lucide="heart" aria-hidden="true" class="w-7 h-7 text-rose-600 dark:text-rose-400"></i>
             </div>
-            <h3 class="text-xl font-semibold mb-2">Built-in Calculator</h3>
-            <p class="text-gray-600 dark:text-gray-400">Scientific calculator available during study for technical questions. No switching apps when you need to do the math.</p>
+            <h3 class="text-xl font-semibold mb-2">Free Forever</h3>
+            <p class="text-gray-600 dark:text-gray-400">100% free and open source. No subscriptions, no ads, no catch. Built by hams, for hams.</p>
           </div>
         </div>
 

--- a/website/js/theme.js
+++ b/website/js/theme.js
@@ -3,9 +3,14 @@
   const STORAGE_KEY = 'theme';
   const DARK_CLASS = 'dark';
 
-  // Get saved theme or default to 'light'
-  function getSavedTheme() {
-    return localStorage.getItem(STORAGE_KEY) || 'light';
+  // Get the effective theme (saved preference or system default)
+  function getEffectiveTheme() {
+    const savedTheme = localStorage.getItem(STORAGE_KEY);
+    if (savedTheme) {
+      return savedTheme;
+    }
+    // Default to system preference
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   }
 
   // Save theme preference
@@ -24,7 +29,7 @@
 
   // Toggle between light and dark
   function toggleTheme() {
-    const currentTheme = getSavedTheme();
+    const currentTheme = getEffectiveTheme();
     const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
     saveTheme(newTheme);
     applyTheme(newTheme);
@@ -32,8 +37,8 @@
 
   // Initialize theme on page load
   function initTheme() {
-    const savedTheme = getSavedTheme();
-    applyTheme(savedTheme);
+    const effectiveTheme = getEffectiveTheme();
+    applyTheme(effectiveTheme);
 
     // Set up theme toggle buttons
     const themeToggle = document.getElementById('theme-toggle');
@@ -46,6 +51,13 @@
     if (themeToggleMobile) {
       themeToggleMobile.addEventListener('click', toggleTheme);
     }
+
+    // Listen for system theme changes (when no saved preference)
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
+      if (!localStorage.getItem(STORAGE_KEY)) {
+        applyTheme(e.matches ? 'dark' : 'light');
+      }
+    });
   }
 
   // Run when DOM is ready


### PR DESCRIPTION
## Summary
- **Delete account input focus**: Fixed input losing focus on each keystroke by converting the DangerView function component to a JSX variable
- **GitHub CTA clickable**: Added `pointer-events: none` to `.feature-card::before` pseudo-element
- **Topic link navigation**: Fixed shared question URL topic links not navigating to dashboard
- **Theme flash**: Added inline script in `<head>` to set dark class before CSS loads
- **Device theme default**: Website now respects system `prefers-color-scheme` preference
- **Readiness score updates**: Reduced staleTime, always invalidate after recalc, use database-backed examType

## Accessibility Improvements
- TopicCard & LessonCard: Added keyboard navigation (Enter/Space), focus styles, aria-labels
- LinkPreview: Added aria-label "(opens in new tab)", focus-visible ring
- Calculator: Added readable aria-labels for operators (Add, Subtract, etc.), aria-live display
- GlossaryHighlightedText: Added role="button", tabIndex, aria-label to tooltip triggers

## Other Changes
- Removed calculator feature from website marketing (replaced with "Free Forever")
- Updated FAQ with community help question

## Test plan
- [x] All 2787 tests pass
- [ ] Verify delete account input keeps focus while typing
- [ ] Verify GitHub CTA is clickable on website
- [ ] Verify topic link navigates from shared question URL
- [ ] Verify no theme flash on page navigation in dark mode
- [ ] Verify fresh browser respects system theme preference
- [ ] Verify readiness score updates after completing practice test
- [ ] Test keyboard navigation on TopicCard, LessonCard, LinkPreview
- [ ] Test screen reader announces Calculator operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)