### PR TITLE
fix: resolve URL length limit error in calculate-readiness Edge Function

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,10 +53,26 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  edge-functions:
+    name: Edge Function Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Run Edge Function tests
+        run: cd supabase/functions && deno test --allow-env --allow-net
+
   build:
     name: Build Check
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, edge-functions]
 
     steps:
       - name: Checkout code

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "dev:full": "npm run supabase:start && npm run dev",
     "supabase:functions": "npx supabase functions serve --no-verify-jwt --env-file supabase/functions/.env.local",
     "supabase:functions:debug": "npx supabase functions serve --no-verify-jwt --env-file supabase/functions/.env.local --debug",
+    "supabase:functions:test": "cd supabase/functions && deno test --allow-env --allow-net",
+    "supabase:functions:test:watch": "cd supabase/functions && deno test --allow-env --allow-net --watch",
     "test": "vitest",
     "test:run": "vitest run",
     "test:ui": "vitest --ui",

--- a/supabase/functions/_shared/test-utils.ts
+++ b/supabase/functions/_shared/test-utils.ts
@@ -1,0 +1,167 @@
+// ============================================================
+// TEST UTILITIES FOR SUPABASE EDGE FUNCTIONS
+// ============================================================
+
+/**
+ * Creates a mock Supabase client for testing.
+ * Returns chainable query builder that can be configured with expected responses.
+ */
+export interface MockQueryBuilder {
+  select: (columns?: string, options?: { count?: string; head?: boolean }) => MockQueryBuilder;
+  eq: (column: string, value: unknown) => MockQueryBuilder;
+  like: (column: string, pattern: string) => MockQueryBuilder;
+  in: (column: string, values: unknown[]) => MockQueryBuilder;
+  gte: (column: string, value: unknown) => MockQueryBuilder;
+  order: (column: string, options?: { ascending?: boolean }) => MockQueryBuilder;
+  maybeSingle: () => Promise<{ data: unknown; error: unknown }>;
+  // Result accessors
+  then: (resolve: (result: { data: unknown; error: unknown; count?: number }) => void) => void;
+}
+
+export interface MockTableConfig {
+  data?: unknown;
+  error?: { message: string } | null;
+  count?: number;
+}
+
+export interface MockSupabaseClient {
+  from: (table: string) => MockQueryBuilder;
+  auth: {
+    getUser: () => Promise<{ data: { user: { id: string } | null }; error: unknown }>;
+  };
+  _setTableResponse: (table: string, config: MockTableConfig) => void;
+  _setAuthUser: (user: { id: string } | null, error?: unknown) => void;
+}
+
+export function createMockSupabaseClient(): MockSupabaseClient {
+  const tableResponses = new Map<string, MockTableConfig>();
+  let authUser: { id: string } | null = { id: "test-user-id" };
+  let authError: unknown = null;
+
+  const createQueryBuilder = (table: string): MockQueryBuilder => {
+    const getResponse = () => {
+      const config = tableResponses.get(table) || { data: [], error: null };
+      return { data: config.data, error: config.error, count: config.count };
+    };
+
+    const builder: MockQueryBuilder = {
+      select: () => builder,
+      eq: () => builder,
+      like: () => builder,
+      in: () => builder,
+      gte: () => builder,
+      order: () => builder,
+      maybeSingle: async () => {
+        const response = getResponse();
+        return { data: response.data, error: response.error };
+      },
+      then: (resolve) => {
+        resolve(getResponse());
+      },
+    };
+
+    return builder;
+  };
+
+  return {
+    from: (table: string) => createQueryBuilder(table),
+    auth: {
+      getUser: async () => ({
+        data: { user: authUser },
+        error: authError,
+      }),
+    },
+    _setTableResponse: (table: string, config: MockTableConfig) => {
+      tableResponses.set(table, config);
+    },
+    _setAuthUser: (user: { id: string } | null, error?: unknown) => {
+      authUser = user;
+      authError = error;
+    },
+  };
+}
+
+/**
+ * Creates a mock HTTP Request object for testing Edge Functions.
+ */
+export function createMockRequest(
+  body: unknown,
+  options: {
+    method?: string;
+    headers?: Record<string, string>;
+  } = {}
+): Request {
+  const { method = "POST", headers = {} } = options;
+
+  return new Request("http://localhost:8000/calculate-readiness", {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer test-token",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Sample test data generators
+ */
+export function createTestAttempts(
+  count: number,
+  correctRatio: number = 0.7
+): Array<{ question_id: string; is_correct: boolean; attempted_at: string }> {
+  const attempts = [];
+  const now = Date.now();
+
+  for (let i = 0; i < count; i++) {
+    attempts.push({
+      question_id: `question-${i}`,
+      is_correct: Math.random() < correctRatio,
+      attempted_at: new Date(now - i * 60000).toISOString(), // 1 minute apart
+    });
+  }
+
+  return attempts;
+}
+
+export function createTestSyllabusData(
+  prefix: string
+): Array<{ code: string; exam_questions: number }> {
+  const subelements =
+    prefix === "T"
+      ? ["T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9", "T0"]
+      : prefix === "G"
+        ? ["G1", "G2", "G3", "G4", "G5", "G6", "G7", "G8", "G9", "G0"]
+        : ["E1", "E2", "E3", "E4", "E5", "E6", "E7", "E8", "E9", "E0"];
+
+  // Approximate weights for each exam type
+  const weights =
+    prefix === "E"
+      ? [5, 5, 5, 5, 5, 5, 5, 5, 5, 5] // Extra has 50 questions
+      : [6, 3, 3, 2, 4, 4, 4, 4, 3, 2]; // Tech/General have 35 questions
+
+  return subelements.map((code, i) => ({
+    code,
+    exam_questions: weights[i],
+  }));
+}
+
+export function createTestQuestions(
+  subelementCodes: string[],
+  questionsPerSubelement: number = 10
+): Array<{ id: string; subelement: string; display_name: string }> {
+  const questions = [];
+
+  for (const code of subelementCodes) {
+    for (let i = 0; i < questionsPerSubelement; i++) {
+      questions.push({
+        id: `${code}-q${i}`,
+        subelement: code,
+        display_name: `${code}A0${i}`,
+      });
+    }
+  }
+
+  return questions;
+}

--- a/supabase/functions/calculate-readiness/logic.test.ts
+++ b/supabase/functions/calculate-readiness/logic.test.ts
@@ -1,0 +1,605 @@
+/**
+ * Unit Tests for calculate-readiness Edge Function Logic
+ * ======================================================
+ *
+ * Tests the pure calculation functions extracted from the Edge Function.
+ * These tests verify mathematical correctness without database dependencies.
+ */
+
+import {
+  assertEquals,
+  assertAlmostEquals,
+  assertGreater,
+  assertLess,
+} from "jsr:@std/assert@1";
+import {
+  validateExamType,
+  examTypeToPrefix,
+  prefixToExamType,
+  calculateReadiness,
+  calculateAccuracyFromAttempts,
+  calculateCoverage,
+  calculateMastery,
+  calculateTestPassRate,
+  calculateDaysSinceStudy,
+  calculateEstimatedAccuracy,
+  calculateBetaModifier,
+  calculateRiskScore,
+  calculateExpectedScore,
+  calculateSingleSubelementMetric,
+  calculateMetricsFromRaw,
+  DEFAULT_CONFIG,
+  type Config,
+  type Metrics,
+} from "./logic.ts";
+
+// =============================================================================
+// Input Validation Tests
+// =============================================================================
+
+Deno.test("validateExamType - accepts valid exam types", () => {
+  assertEquals(validateExamType("technician"), true);
+  assertEquals(validateExamType("general"), true);
+  assertEquals(validateExamType("extra"), true);
+});
+
+Deno.test("validateExamType - rejects invalid exam types", () => {
+  assertEquals(validateExamType("invalid"), false);
+  assertEquals(validateExamType(""), false);
+  assertEquals(validateExamType(null), false);
+  assertEquals(validateExamType(undefined), false);
+  assertEquals(validateExamType(123), false);
+  assertEquals(validateExamType({}), false);
+});
+
+Deno.test("examTypeToPrefix - converts correctly", () => {
+  assertEquals(examTypeToPrefix("technician"), "T");
+  assertEquals(examTypeToPrefix("general"), "G");
+  assertEquals(examTypeToPrefix("extra"), "E");
+});
+
+Deno.test("prefixToExamType - converts correctly", () => {
+  assertEquals(prefixToExamType("T"), "technician");
+  assertEquals(prefixToExamType("G"), "general");
+  assertEquals(prefixToExamType("E"), "extra");
+});
+
+// =============================================================================
+// Readiness Calculation Tests
+// =============================================================================
+
+Deno.test("calculateReadiness - perfect score with no recency penalty", () => {
+  const metrics: Metrics = {
+    recentAccuracy: 1.0,
+    overallAccuracy: 1.0,
+    coverage: 1.0,
+    mastery: 1.0,
+    testsPassed: 5,
+    testsTaken: 5,
+    testPassRate: 1.0,
+    daysSinceStudy: 0,
+    lastStudyAt: new Date().toISOString(),
+    totalAttempts: 100,
+    uniqueQuestionsSeen: 100,
+    totalPoolSize: 100,
+  };
+
+  const result = calculateReadiness(metrics, DEFAULT_CONFIG);
+
+  // 35*1 + 20*1 + 15*1 + 15*1 + 15*1 = 100
+  assertEquals(result.readinessScore, 100);
+  assertGreater(result.passProbability, 0.99);
+  assertEquals(result.recencyPenalty, 0);
+});
+
+Deno.test("calculateReadiness - zero score for no activity", () => {
+  const metrics: Metrics = {
+    recentAccuracy: 0,
+    overallAccuracy: 0,
+    coverage: 0,
+    mastery: 0,
+    testsPassed: 0,
+    testsTaken: 1,
+    testPassRate: 0,
+    daysSinceStudy: 0,
+    lastStudyAt: null,
+    totalAttempts: 0,
+    uniqueQuestionsSeen: 0,
+    totalPoolSize: 100,
+  };
+
+  const result = calculateReadiness(metrics, DEFAULT_CONFIG);
+
+  assertEquals(result.readinessScore, 0);
+  assertLess(result.passProbability, 0.01);
+});
+
+Deno.test("calculateReadiness - applies recency penalty", () => {
+  const metricsRecent: Metrics = {
+    recentAccuracy: 0.8,
+    overallAccuracy: 0.8,
+    coverage: 0.8,
+    mastery: 0.8,
+    testsPassed: 4,
+    testsTaken: 5,
+    testPassRate: 0.8,
+    daysSinceStudy: 0,
+    lastStudyAt: new Date().toISOString(),
+    totalAttempts: 100,
+    uniqueQuestionsSeen: 80,
+    totalPoolSize: 100,
+  };
+
+  const metricsStale: Metrics = {
+    ...metricsRecent,
+    daysSinceStudy: 20, // 20 days = max penalty of 10
+  };
+
+  const resultRecent = calculateReadiness(metricsRecent, DEFAULT_CONFIG);
+  const resultStale = calculateReadiness(metricsStale, DEFAULT_CONFIG);
+
+  assertEquals(resultStale.recencyPenalty, 10); // Max penalty
+  assertEquals(resultRecent.readinessScore - resultStale.readinessScore, 10);
+});
+
+Deno.test("calculateReadiness - recency penalty caps at max", () => {
+  const metrics: Metrics = {
+    recentAccuracy: 1.0,
+    overallAccuracy: 1.0,
+    coverage: 1.0,
+    mastery: 1.0,
+    testsPassed: 5,
+    testsTaken: 5,
+    testPassRate: 1.0,
+    daysSinceStudy: 100, // Way more than max penalty threshold
+    lastStudyAt: null,
+    totalAttempts: 100,
+    uniqueQuestionsSeen: 100,
+    totalPoolSize: 100,
+  };
+
+  const result = calculateReadiness(metrics, DEFAULT_CONFIG);
+
+  assertEquals(result.recencyPenalty, 10); // Capped at max_penalty
+  assertEquals(result.readinessScore, 90); // 100 - 10
+});
+
+Deno.test("calculateReadiness - weighted calculation", () => {
+  const metrics: Metrics = {
+    recentAccuracy: 0.8,
+    overallAccuracy: 0.6,
+    coverage: 0.5,
+    mastery: 0.4,
+    testsPassed: 2,
+    testsTaken: 4,
+    testPassRate: 0.5,
+    daysSinceStudy: 0,
+    lastStudyAt: new Date().toISOString(),
+    totalAttempts: 50,
+    uniqueQuestionsSeen: 50,
+    totalPoolSize: 100,
+  };
+
+  const result = calculateReadiness(metrics, DEFAULT_CONFIG);
+
+  // 35*0.8 + 20*0.6 + 15*0.5 + 15*0.4 + 15*0.5 = 28 + 12 + 7.5 + 6 + 7.5 = 61
+  assertEquals(result.readinessScore, 61);
+});
+
+Deno.test("calculateReadiness - handles null accuracy values", () => {
+  const metrics: Metrics = {
+    recentAccuracy: null,
+    overallAccuracy: null,
+    coverage: 0.5,
+    mastery: 0.5,
+    testsPassed: 0,
+    testsTaken: 0,
+    testPassRate: 0,
+    daysSinceStudy: 0,
+    lastStudyAt: null,
+    totalAttempts: 0,
+    uniqueQuestionsSeen: 50,
+    totalPoolSize: 100,
+  };
+
+  const result = calculateReadiness(metrics, DEFAULT_CONFIG);
+
+  // 35*0 + 20*0 + 15*0.5 + 15*0.5 + 15*0 = 15
+  assertEquals(result.readinessScore, 15);
+});
+
+Deno.test("calculateReadiness - pass probability at r0 threshold is 0.5", () => {
+  // Create metrics that produce a score of exactly 65 (r0 threshold)
+  const metrics: Metrics = {
+    recentAccuracy: 1.0,
+    overallAccuracy: 1.0,
+    coverage: 0.5,
+    mastery: 0.5,
+    testsPassed: 0,
+    testsTaken: 0,
+    testPassRate: 0,
+    daysSinceStudy: 0,
+    lastStudyAt: new Date().toISOString(),
+    totalAttempts: 100,
+    uniqueQuestionsSeen: 50,
+    totalPoolSize: 100,
+  };
+
+  const result = calculateReadiness(metrics, DEFAULT_CONFIG);
+  // 35*1 + 20*1 + 15*0.5 + 15*0.5 + 15*0 = 35 + 20 + 7.5 + 7.5 = 70
+
+  // At r0=65, probability should be 0.5
+  const customConfig: Config = {
+    ...DEFAULT_CONFIG,
+    pass_probability: { k: 0.15, r0: 70 }, // Set r0 to match our score
+  };
+
+  const resultAtThreshold = calculateReadiness(metrics, customConfig);
+  assertAlmostEquals(resultAtThreshold.passProbability, 0.5, 0.01);
+});
+
+// =============================================================================
+// Accuracy Calculation Tests
+// =============================================================================
+
+Deno.test("calculateAccuracyFromAttempts - empty array returns null", () => {
+  assertEquals(calculateAccuracyFromAttempts([]), null);
+});
+
+Deno.test("calculateAccuracyFromAttempts - all correct", () => {
+  const attempts = [
+    { is_correct: true },
+    { is_correct: true },
+    { is_correct: true },
+  ];
+  assertEquals(calculateAccuracyFromAttempts(attempts), 1.0);
+});
+
+Deno.test("calculateAccuracyFromAttempts - all incorrect", () => {
+  const attempts = [
+    { is_correct: false },
+    { is_correct: false },
+    { is_correct: false },
+  ];
+  assertEquals(calculateAccuracyFromAttempts(attempts), 0);
+});
+
+Deno.test("calculateAccuracyFromAttempts - mixed results", () => {
+  const attempts = [
+    { is_correct: true },
+    { is_correct: false },
+    { is_correct: true },
+    { is_correct: false },
+  ];
+  assertEquals(calculateAccuracyFromAttempts(attempts), 0.5);
+});
+
+// =============================================================================
+// Coverage and Mastery Tests
+// =============================================================================
+
+Deno.test("calculateCoverage - full coverage", () => {
+  assertEquals(calculateCoverage(100, 100), 1.0);
+});
+
+Deno.test("calculateCoverage - partial coverage", () => {
+  assertEquals(calculateCoverage(50, 100), 0.5);
+});
+
+Deno.test("calculateCoverage - zero pool size returns 0", () => {
+  assertEquals(calculateCoverage(50, 0), 0);
+});
+
+Deno.test("calculateMastery - full mastery", () => {
+  assertEquals(calculateMastery(100, 100), 1.0);
+});
+
+Deno.test("calculateMastery - partial mastery", () => {
+  assertEquals(calculateMastery(25, 100), 0.25);
+});
+
+Deno.test("calculateMastery - zero pool size returns 0", () => {
+  assertEquals(calculateMastery(25, 0), 0);
+});
+
+Deno.test("calculateTestPassRate - all passed", () => {
+  assertEquals(calculateTestPassRate(5, 5), 1.0);
+});
+
+Deno.test("calculateTestPassRate - none passed", () => {
+  assertEquals(calculateTestPassRate(0, 5), 0);
+});
+
+Deno.test("calculateTestPassRate - zero tests returns 0", () => {
+  assertEquals(calculateTestPassRate(0, 0), 0);
+});
+
+// =============================================================================
+// Days Since Study Tests
+// =============================================================================
+
+Deno.test("calculateDaysSinceStudy - null returns 30", () => {
+  assertEquals(calculateDaysSinceStudy(null), 30);
+});
+
+Deno.test("calculateDaysSinceStudy - recent date", () => {
+  const now = new Date();
+  const result = calculateDaysSinceStudy(now.toISOString());
+  assertLess(result, 0.01); // Should be very close to 0
+});
+
+Deno.test("calculateDaysSinceStudy - one day ago", () => {
+  const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const result = calculateDaysSinceStudy(yesterday.toISOString());
+  assertAlmostEquals(result, 1, 0.01);
+});
+
+// =============================================================================
+// Estimated Accuracy Blend Tests
+// =============================================================================
+
+Deno.test("calculateEstimatedAccuracy - uses overall for < min_recent", () => {
+  const result = calculateEstimatedAccuracy(0.9, 0.6, 4, DEFAULT_CONFIG.blend);
+  assertEquals(result, 0.6);
+});
+
+Deno.test("calculateEstimatedAccuracy - uses recent for >= recent_window", () => {
+  const result = calculateEstimatedAccuracy(0.9, 0.6, 20, DEFAULT_CONFIG.blend);
+  assertEquals(result, 0.9);
+});
+
+Deno.test("calculateEstimatedAccuracy - blends for intermediate counts", () => {
+  // At 10 attempts: alpha = 10/20 = 0.5
+  // Blend = 0.5 * 0.9 + 0.5 * 0.6 = 0.75
+  const result = calculateEstimatedAccuracy(0.9, 0.6, 10, DEFAULT_CONFIG.blend);
+  assertAlmostEquals(result, 0.75, 0.001);
+});
+
+Deno.test("calculateEstimatedAccuracy - handles null accuracies", () => {
+  const result = calculateEstimatedAccuracy(null, null, 10, DEFAULT_CONFIG.blend);
+  assertEquals(result, 0);
+});
+
+// =============================================================================
+// Beta Modifier Tests
+// =============================================================================
+
+Deno.test("calculateBetaModifier - low coverage returns 1.2", () => {
+  assertEquals(calculateBetaModifier(0.1, DEFAULT_CONFIG.coverage_beta), 1.2);
+  assertEquals(calculateBetaModifier(0.29, DEFAULT_CONFIG.coverage_beta), 1.2);
+});
+
+Deno.test("calculateBetaModifier - mid coverage returns 1.0", () => {
+  assertEquals(calculateBetaModifier(0.3, DEFAULT_CONFIG.coverage_beta), 1.0);
+  assertEquals(calculateBetaModifier(0.5, DEFAULT_CONFIG.coverage_beta), 1.0);
+  assertEquals(calculateBetaModifier(0.69, DEFAULT_CONFIG.coverage_beta), 1.0);
+});
+
+Deno.test("calculateBetaModifier - high coverage returns 0.9", () => {
+  assertEquals(calculateBetaModifier(0.7, DEFAULT_CONFIG.coverage_beta), 0.9);
+  assertEquals(calculateBetaModifier(0.9, DEFAULT_CONFIG.coverage_beta), 0.9);
+  assertEquals(calculateBetaModifier(1.0, DEFAULT_CONFIG.coverage_beta), 0.9);
+});
+
+// =============================================================================
+// Risk and Expected Score Tests
+// =============================================================================
+
+Deno.test("calculateRiskScore - low coverage increases risk", () => {
+  // Low coverage (beta = 1.2): risk = 6 * (1 - 0.8) * 1.2 = 1.44
+  const result = calculateRiskScore(6, 0.8, 0.2, DEFAULT_CONFIG.coverage_beta);
+  assertAlmostEquals(result, 1.44, 0.001);
+});
+
+Deno.test("calculateRiskScore - high coverage reduces risk", () => {
+  // High coverage (beta = 0.9): risk = 6 * (1 - 0.8) * 0.9 = 1.08
+  const result = calculateRiskScore(6, 0.8, 0.8, DEFAULT_CONFIG.coverage_beta);
+  assertAlmostEquals(result, 1.08, 0.001);
+});
+
+Deno.test("calculateRiskScore - perfect accuracy has zero risk", () => {
+  const result = calculateRiskScore(6, 1.0, 0.5, DEFAULT_CONFIG.coverage_beta);
+  assertEquals(result, 0);
+});
+
+Deno.test("calculateExpectedScore - correct calculation", () => {
+  assertAlmostEquals(calculateExpectedScore(6, 0.8), 4.8, 0.001);
+  assertEquals(calculateExpectedScore(4, 0.5), 2);
+  assertEquals(calculateExpectedScore(3, 1.0), 3);
+  assertEquals(calculateExpectedScore(6, 0), 0);
+});
+
+// =============================================================================
+// Subelement Metric Tests
+// =============================================================================
+
+Deno.test("calculateSingleSubelementMetric - empty attempts", () => {
+  const result = calculateSingleSubelementMetric(
+    {
+      code: "T1",
+      weight: 6,
+      poolSize: 50,
+      attempts: [],
+      masteredQuestionIds: new Set(),
+    },
+    DEFAULT_CONFIG
+  );
+
+  assertEquals(result.accuracy, null);
+  assertEquals(result.recent_accuracy, null);
+  assertEquals(result.coverage, 0);
+  assertEquals(result.mastery, 0);
+  assertEquals(result.attempts_count, 0);
+  assertEquals(result.weight, 6);
+  assertEquals(result.pool_size, 50);
+});
+
+Deno.test("calculateSingleSubelementMetric - with attempts and mastery", () => {
+  const attempts = [
+    { question_id: "q1", is_correct: true, attempted_at: "2024-01-10T00:00:00Z" },
+    { question_id: "q2", is_correct: true, attempted_at: "2024-01-09T00:00:00Z" },
+    { question_id: "q3", is_correct: false, attempted_at: "2024-01-08T00:00:00Z" },
+    { question_id: "q1", is_correct: true, attempted_at: "2024-01-07T00:00:00Z" },
+  ];
+
+  const result = calculateSingleSubelementMetric(
+    {
+      code: "T1",
+      weight: 6,
+      poolSize: 10,
+      attempts,
+      masteredQuestionIds: new Set(["q1", "q2"]),
+    },
+    DEFAULT_CONFIG
+  );
+
+  assertEquals(result.accuracy, 0.75); // 3/4 correct
+  assertEquals(result.recent_accuracy, 0.75); // All 4 within recent window
+  assertEquals(result.coverage, 0.3); // 3 unique questions / 10 pool
+  assertEquals(result.mastery, 0.2); // 2 mastered / 10 pool
+  assertEquals(result.attempts_count, 4);
+  assertEquals(result.recent_attempts_count, 4);
+  assertEquals(result.weight, 6);
+});
+
+// =============================================================================
+// Metrics From Raw Data Tests
+// =============================================================================
+
+Deno.test("calculateMetricsFromRaw - complete scenario", () => {
+  const now = Date.now();
+  const attempts = [
+    { question_id: "q1", is_correct: true, attempted_at: new Date(now).toISOString() },
+    { question_id: "q2", is_correct: true, attempted_at: new Date(now - 60000).toISOString() },
+    { question_id: "q3", is_correct: false, attempted_at: new Date(now - 120000).toISOString() },
+    { question_id: "q4", is_correct: true, attempted_at: new Date(now - 180000).toISOString() },
+  ];
+
+  const result = calculateMetricsFromRaw({
+    attempts,
+    masteredCount: 10,
+    totalPoolSize: 100,
+    testsPassed: 3,
+    testsTaken: 5,
+    recentWindow: 10,
+  });
+
+  assertEquals(result.totalAttempts, 4);
+  assertEquals(result.recentAccuracy, 0.75);
+  assertEquals(result.overallAccuracy, 0.75);
+  assertEquals(result.uniqueQuestionsSeen, 4);
+  assertEquals(result.coverage, 0.04);
+  assertEquals(result.mastery, 0.1);
+  assertEquals(result.testsPassed, 3);
+  assertEquals(result.testsTaken, 5);
+  assertEquals(result.testPassRate, 0.6);
+  assertEquals(result.totalPoolSize, 100);
+});
+
+Deno.test("calculateMetricsFromRaw - empty attempts", () => {
+  const result = calculateMetricsFromRaw({
+    attempts: [],
+    masteredCount: 0,
+    totalPoolSize: 100,
+    testsPassed: 0,
+    testsTaken: 0,
+    recentWindow: 50,
+  });
+
+  assertEquals(result.totalAttempts, 0);
+  assertEquals(result.recentAccuracy, null);
+  assertEquals(result.overallAccuracy, null);
+  assertEquals(result.uniqueQuestionsSeen, 0);
+  assertEquals(result.coverage, 0);
+  assertEquals(result.mastery, 0);
+  assertEquals(result.testPassRate, 0);
+  assertEquals(result.daysSinceStudy, 30);
+  assertEquals(result.lastStudyAt, null);
+});
+
+// =============================================================================
+// Edge Cases
+// =============================================================================
+
+Deno.test("edge case - score clamped to 0-100 range", () => {
+  // Very high penalty that would make score negative
+  const metrics: Metrics = {
+    recentAccuracy: 0.1,
+    overallAccuracy: 0.1,
+    coverage: 0.1,
+    mastery: 0.1,
+    testsPassed: 0,
+    testsTaken: 1,
+    testPassRate: 0,
+    daysSinceStudy: 100,
+    lastStudyAt: null,
+    totalAttempts: 10,
+    uniqueQuestionsSeen: 10,
+    totalPoolSize: 100,
+  };
+
+  const result = calculateReadiness(metrics, DEFAULT_CONFIG);
+
+  // Raw: 35*0.1 + 20*0.1 + 15*0.1 + 15*0.1 + 15*0 - 10 = 8.5 - 10 = -1.5
+  // But should be clamped to 0
+  assertEquals(result.readinessScore, 0);
+});
+
+Deno.test("edge case - custom config weights", () => {
+  const customConfig: Config = {
+    ...DEFAULT_CONFIG,
+    formula_weights: {
+      recent_accuracy: 50,
+      overall_accuracy: 25,
+      coverage: 10,
+      mastery: 10,
+      test_rate: 5,
+    },
+  };
+
+  const metrics: Metrics = {
+    recentAccuracy: 1.0,
+    overallAccuracy: 1.0,
+    coverage: 1.0,
+    mastery: 1.0,
+    testsPassed: 1,
+    testsTaken: 1,
+    testPassRate: 1.0,
+    daysSinceStudy: 0,
+    lastStudyAt: new Date().toISOString(),
+    totalAttempts: 100,
+    uniqueQuestionsSeen: 100,
+    totalPoolSize: 100,
+  };
+
+  const result = calculateReadiness(metrics, customConfig);
+  assertEquals(result.readinessScore, 100);
+});
+
+// =============================================================================
+// DEFAULT_CONFIG Validation Tests
+// =============================================================================
+
+Deno.test("DEFAULT_CONFIG - weights sum to 100", () => {
+  const w = DEFAULT_CONFIG.formula_weights;
+  const sum = w.recent_accuracy + w.overall_accuracy + w.coverage + w.mastery + w.test_rate;
+  assertEquals(sum, 100);
+});
+
+Deno.test("DEFAULT_CONFIG - valid pass probability parameters", () => {
+  assertGreater(DEFAULT_CONFIG.pass_probability.k, 0);
+  assertGreater(DEFAULT_CONFIG.pass_probability.r0, 0);
+  assertLess(DEFAULT_CONFIG.pass_probability.r0, 100);
+});
+
+Deno.test("DEFAULT_CONFIG - valid recency penalty parameters", () => {
+  assertGreater(DEFAULT_CONFIG.recency_penalty.max_penalty, 0);
+  assertGreater(DEFAULT_CONFIG.recency_penalty.decay_rate, 0);
+});
+
+Deno.test("DEFAULT_CONFIG - valid coverage beta thresholds", () => {
+  assertLess(
+    DEFAULT_CONFIG.coverage_beta.low_threshold,
+    DEFAULT_CONFIG.coverage_beta.high_threshold
+  );
+});

--- a/supabase/functions/calculate-readiness/logic.ts
+++ b/supabase/functions/calculate-readiness/logic.ts
@@ -1,0 +1,387 @@
+// ============================================================
+// PURE CALCULATION LOGIC - Extracted for testability
+// ============================================================
+
+// Type definitions
+export interface FormulaWeights {
+  recent_accuracy: number;
+  overall_accuracy: number;
+  coverage: number;
+  mastery: number;
+  test_rate: number;
+}
+
+export interface PassProbabilityConfig {
+  k: number;
+  r0: number;
+}
+
+export interface RecencyPenaltyConfig {
+  max_penalty: number;
+  decay_rate: number;
+}
+
+export interface CoverageBetaConfig {
+  low: number;
+  mid: number;
+  high: number;
+  low_threshold: number;
+  high_threshold: number;
+}
+
+export interface BlendConfig {
+  min_recent_for_blend: number;
+  recent_window: number;
+}
+
+export interface ThresholdsConfig {
+  min_attempts: number;
+  min_per_subelement: number;
+  recent_window: number;
+  subelement_recent_window: number;
+}
+
+export interface Config {
+  formula_weights: FormulaWeights;
+  pass_probability: PassProbabilityConfig;
+  recency_penalty: RecencyPenaltyConfig;
+  coverage_beta: CoverageBetaConfig;
+  blend: BlendConfig;
+  thresholds: ThresholdsConfig;
+  version: string;
+}
+
+export interface Metrics {
+  recentAccuracy: number | null;
+  overallAccuracy: number | null;
+  coverage: number;
+  mastery: number;
+  testsPassed: number;
+  testsTaken: number;
+  testPassRate: number;
+  daysSinceStudy: number;
+  lastStudyAt: string | null;
+  totalAttempts: number;
+  uniqueQuestionsSeen: number;
+  totalPoolSize: number;
+}
+
+export interface SubelementMetric {
+  accuracy: number | null;
+  recent_accuracy: number | null;
+  coverage: number;
+  mastery: number;
+  risk_score: number;
+  expected_score: number;
+  weight: number;
+  pool_size: number;
+  attempts_count: number;
+  recent_attempts_count: number;
+}
+
+export interface ReadinessResult {
+  readinessScore: number;
+  passProbability: number;
+  recencyPenalty: number;
+  expectedExamScore: number;
+}
+
+export interface SubelementData {
+  code: string;
+  weight: number;
+}
+
+export interface AttemptData {
+  question_id: string;
+  is_correct: boolean;
+  attempted_at: string;
+}
+
+// ============================================================
+// DEFAULT CONFIGURATION
+// ============================================================
+
+export const DEFAULT_CONFIG: Config = {
+  formula_weights: {
+    recent_accuracy: 35,
+    overall_accuracy: 20,
+    coverage: 15,
+    mastery: 15,
+    test_rate: 15,
+  },
+  pass_probability: {
+    k: 0.15,
+    r0: 65,
+  },
+  recency_penalty: {
+    max_penalty: 10,
+    decay_rate: 0.5,
+  },
+  coverage_beta: {
+    low: 1.2,
+    mid: 1.0,
+    high: 0.9,
+    low_threshold: 0.3,
+    high_threshold: 0.7,
+  },
+  blend: {
+    min_recent_for_blend: 5,
+    recent_window: 20,
+  },
+  thresholds: {
+    min_attempts: 50,
+    min_per_subelement: 2,
+    recent_window: 50,
+    subelement_recent_window: 20,
+  },
+  version: "v1.0.0-default",
+};
+
+// ============================================================
+// INPUT VALIDATION
+// ============================================================
+
+export function validateExamType(examType: unknown): examType is "technician" | "general" | "extra" {
+  return typeof examType === "string" &&
+    ["technician", "general", "extra"].includes(examType);
+}
+
+export function examTypeToPrefix(examType: "technician" | "general" | "extra"): string {
+  return examType === "technician" ? "T" : examType === "general" ? "G" : "E";
+}
+
+export function prefixToExamType(prefix: string): "technician" | "general" | "extra" {
+  return prefix === "T" ? "technician" : prefix === "G" ? "general" : "extra";
+}
+
+// ============================================================
+// READINESS CALCULATION
+// ============================================================
+
+export function calculateReadiness(metrics: Metrics, config: Config): ReadinessResult {
+  const w = config.formula_weights;
+
+  // Readiness Score: R = w1*A_r + w2*A_o + w3*C + w4*M + w5*T_rate - penalty
+  const rawScore =
+    w.recent_accuracy * (metrics.recentAccuracy ?? 0) +
+    w.overall_accuracy * (metrics.overallAccuracy ?? 0) +
+    w.coverage * metrics.coverage +
+    w.mastery * metrics.mastery +
+    w.test_rate * metrics.testPassRate;
+
+  // Recency penalty: penalty = min(max_penalty, decay_rate * days)
+  const recencyPenalty = Math.min(
+    config.recency_penalty.max_penalty,
+    config.recency_penalty.decay_rate * metrics.daysSinceStudy
+  );
+
+  // Clamp final score to 0-100
+  const readinessScore = Math.max(0, Math.min(100, rawScore - recencyPenalty));
+
+  // Pass probability using logistic function: P = 1 / (1 + e^(-k(R - R_0)))
+  const { k, r0 } = config.pass_probability;
+  const passProbability = 1 / (1 + Math.exp(-k * (readinessScore - r0)));
+
+  return {
+    readinessScore,
+    passProbability,
+    recencyPenalty,
+    expectedExamScore: 0,
+  };
+}
+
+// ============================================================
+// METRICS CALCULATION HELPERS
+// ============================================================
+
+export function calculateAccuracyFromAttempts(
+  attempts: Array<{ is_correct: boolean }>
+): number | null {
+  if (attempts.length === 0) return null;
+  const correct = attempts.filter((a) => a.is_correct).length;
+  return correct / attempts.length;
+}
+
+export function calculateCoverage(uniqueQuestionsSeen: number, totalPoolSize: number): number {
+  return totalPoolSize > 0 ? uniqueQuestionsSeen / totalPoolSize : 0;
+}
+
+export function calculateMastery(masteredCount: number, totalPoolSize: number): number {
+  return totalPoolSize > 0 ? masteredCount / totalPoolSize : 0;
+}
+
+export function calculateTestPassRate(testsPassed: number, testsTaken: number): number {
+  return testsTaken > 0 ? testsPassed / testsTaken : 0;
+}
+
+export function calculateDaysSinceStudy(lastStudyAt: string | null): number {
+  if (!lastStudyAt) return 30;
+  return (Date.now() - new Date(lastStudyAt).getTime()) / (1000 * 60 * 60 * 24);
+}
+
+// ============================================================
+// SUBELEMENT METRICS CALCULATION
+// ============================================================
+
+export function calculateEstimatedAccuracy(
+  recentAccuracy: number | null,
+  overallAccuracy: number | null,
+  recentAttemptsCount: number,
+  config: BlendConfig
+): number {
+  if (recentAttemptsCount >= config.recent_window) {
+    return recentAccuracy ?? 0;
+  } else if (recentAttemptsCount >= config.min_recent_for_blend) {
+    const alpha = recentAttemptsCount / config.recent_window;
+    return alpha * (recentAccuracy ?? 0) + (1 - alpha) * (overallAccuracy ?? 0);
+  } else {
+    return overallAccuracy ?? 0;
+  }
+}
+
+export function calculateBetaModifier(coverage: number, config: CoverageBetaConfig): number {
+  if (coverage < config.low_threshold) {
+    return config.low;
+  } else if (coverage >= config.high_threshold) {
+    return config.high;
+  } else {
+    return config.mid;
+  }
+}
+
+export function calculateRiskScore(
+  weight: number,
+  estimatedAccuracy: number,
+  coverage: number,
+  betaConfig: CoverageBetaConfig
+): number {
+  const beta = calculateBetaModifier(coverage, betaConfig);
+  return weight * (1 - estimatedAccuracy) * beta;
+}
+
+export function calculateExpectedScore(weight: number, estimatedAccuracy: number): number {
+  return weight * estimatedAccuracy;
+}
+
+export interface SubelementInput {
+  code: string;
+  weight: number;
+  poolSize: number;
+  attempts: AttemptData[];
+  masteredQuestionIds: Set<string>;
+}
+
+export function calculateSingleSubelementMetric(
+  input: SubelementInput,
+  config: Config
+): SubelementMetric {
+  const { weight, poolSize, attempts, masteredQuestionIds } = input;
+
+  const attemptsCount = attempts.length;
+  const correctCount = attempts.filter((a) => a.is_correct).length;
+  const accuracy = attemptsCount > 0 ? correctCount / attemptsCount : null;
+
+  // Recent accuracy (last N per subelement) - assumes attempts are sorted by date desc
+  const recentWindow = config.thresholds.subelement_recent_window;
+  const recentAttempts = attempts.slice(0, recentWindow);
+  const recentCorrect = recentAttempts.filter((a) => a.is_correct).length;
+  const recentAccuracy = recentAttempts.length > 0 ? recentCorrect / recentAttempts.length : null;
+  const recentAttemptsCount = recentAttempts.length;
+
+  // Coverage - unique questions seen
+  const uniqueQuestionsSeen = new Set(attempts.map((a) => a.question_id)).size;
+  const coverage = poolSize > 0 ? uniqueQuestionsSeen / poolSize : 0;
+
+  // Mastery
+  const mastery = poolSize > 0 ? masteredQuestionIds.size / poolSize : 0;
+
+  // Estimated accuracy using blend formula
+  const estimatedAccuracy = calculateEstimatedAccuracy(
+    recentAccuracy,
+    accuracy,
+    recentAttemptsCount,
+    config.blend
+  );
+
+  // Risk and expected scores
+  const riskScore = calculateRiskScore(weight, estimatedAccuracy, coverage, config.coverage_beta);
+  const expectedScore = calculateExpectedScore(weight, estimatedAccuracy);
+
+  return {
+    accuracy,
+    recent_accuracy: recentAccuracy,
+    coverage,
+    mastery,
+    risk_score: riskScore,
+    expected_score: expectedScore,
+    weight,
+    pool_size: poolSize,
+    attempts_count: attemptsCount,
+    recent_attempts_count: recentAttemptsCount,
+  };
+}
+
+// ============================================================
+// AGGREGATE METRICS FROM RAW DATA
+// ============================================================
+
+export interface RawMetricsInput {
+  attempts: Array<{ is_correct: boolean; attempted_at: string; question_id: string }>;
+  masteredCount: number;
+  totalPoolSize: number;
+  testsPassed: number;
+  testsTaken: number;
+  recentWindow: number;
+}
+
+export function calculateMetricsFromRaw(input: RawMetricsInput): Metrics {
+  const {
+    attempts,
+    masteredCount,
+    totalPoolSize,
+    testsPassed,
+    testsTaken,
+    recentWindow,
+  } = input;
+
+  const totalAttempts = attempts.length;
+
+  // Recent accuracy (last N questions)
+  const recentAttempts = attempts.slice(0, recentWindow);
+  const recentCorrect = recentAttempts.filter((a) => a.is_correct).length;
+  const recentAccuracy = recentAttempts.length > 0 ? recentCorrect / recentAttempts.length : null;
+
+  // Overall accuracy
+  const overallCorrect = attempts.filter((a) => a.is_correct).length;
+  const overallAccuracy = totalAttempts > 0 ? overallCorrect / totalAttempts : null;
+
+  // Unique questions seen (coverage)
+  const uniqueQuestionIds = new Set(attempts.map((a) => a.question_id));
+  const uniqueQuestionsSeen = uniqueQuestionIds.size;
+  const coverage = calculateCoverage(uniqueQuestionsSeen, totalPoolSize);
+
+  // Mastery
+  const mastery = calculateMastery(masteredCount, totalPoolSize);
+
+  // Test pass rate
+  const testPassRate = calculateTestPassRate(testsPassed, testsTaken);
+
+  // Days since last study
+  const lastStudyAt = attempts.length > 0 ? attempts[0].attempted_at : null;
+  const daysSinceStudy = calculateDaysSinceStudy(lastStudyAt);
+
+  return {
+    recentAccuracy,
+    overallAccuracy,
+    coverage,
+    mastery,
+    testsPassed,
+    testsTaken,
+    testPassRate,
+    daysSinceStudy,
+    lastStudyAt,
+    totalAttempts,
+    uniqueQuestionsSeen,
+    totalPoolSize,
+  };
+}

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "lib": ["deno.ns", "deno.unstable"]
+  },
+  "imports": {
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2",
+    "@supabase/functions-js/edge-runtime.d.ts": "jsr:@supabase/functions-js/edge-runtime.d.ts",
+    "@std/assert": "jsr:@std/assert@1",
+    "@std/testing": "jsr:@std/testing@1"
+  },
+  "tasks": {
+    "test": "deno test --allow-env --allow-net",
+    "test:watch": "deno test --allow-env --allow-net --watch"
+  }
+}


### PR DESCRIPTION
## Summary

- Fixed `TypeError: error sending request` caused by URL length limits when passing 400+ UUIDs via `.in()` filter in the calculate-readiness Edge Function
- Replaced `.in(question_id, questionIds)` queries with database JOINs that filter by `questions.display_name` or `questions.subelement`
- Extracted pure calculation logic to `logic.ts` for testability
- Added comprehensive unit test infrastructure for Edge Functions (~50 tests)

## Test plan

- [ ] Verify the Edge Function works for users with many question attempts (previously failing)
- [ ] Run `npm run supabase:functions:test` locally with Deno installed to execute unit tests
- [ ] Verify readiness calculation results match expected behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)