### PR TITLE
feat: implement guest mode — unauthenticated access with save-moment …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,8 +88,9 @@ useQuery({
 
 The service layer foundation in `src/services/` includes:
 - `queryKeys.ts` - Centralized cache key registry (~60 keys)
-- `types.ts` - `ServiceResult<T>`, `ServiceError` types for future services
+- `types.ts` - `ServiceResult<T>`, `ServiceError` types
 - `shared/serviceBase.ts` - Base class for Supabase error handling
+- Subdirectories: `bookmarks/`, `dashboard/`, `examSession/`, `feedback/`, `glossary/`, `progress/`, `readiness/`, `search/`, `streak/`, `weeklyGoals/`
 
 **Cache Invalidation Patterns**:
 
@@ -251,6 +252,28 @@ When saving question attempts, use these `attempt_type` values:
 - `'weak_questions'` - From weak questions review
 - `'topic_quiz'` - From topic mastery quizzes (80% required to complete topic)
 
+### Guest Mode
+
+The app supports unauthenticated ("guest") access. Auth is only required to persist data.
+
+**What works without auth:**
+- All questions (public data — `useQuestions` has no auth requirement)
+- Practice Test, Random Practice, Study by Topic, Glossary
+
+**What requires auth (shows inline placeholder copy instead):**
+- Readiness score, streak, weak questions, recent tests, bookmarks
+
+**The `enabled: !!user` pattern**: All user-scoped TanStack Query hooks use `enabled: !!user`. When `user` is null, those queries never execute — no requests, no errors. Do not remove this guard.
+
+**Save-moment prompts** (dismissible, non-blocking — never gate content):
+- After practice test: inline card below score (`TestResults.tsx`)
+- Clicking bookmark icon: popover tooltip (`QuestionCard.tsx`)
+- Leaving random practice session: Sonner toast (`RandomPractice.tsx`)
+
+**Guest banner**: Dismissible blue banner on Dashboard. Dismissed state stored in `localStorage` key `guest_banner_dismissed`.
+
+**Copy rule**: Always explain what an account *enables technically*, never why the user "should" sign up. See `docs/superpowers/specs/2026-05-20-guest-mode-design.md`.
+
 ## Local Development Setup
 
 ### Prerequisites
@@ -336,6 +359,7 @@ Tests are colocated with components (e.g., `QuestionCard.test.tsx` next to `Ques
 4. **Don't create monolithic components** - Extract reusable pieces, keep files under 200 lines
 5. **Don't forget mobile** - The app is responsive; test on mobile viewports
 6. **Don't skip theme testing** - Verify both light and dark modes work
+7. **Don't add auth guards to `/dashboard`** - Dashboard is intentionally guest-accessible; `!user` renders guest placeholders, not a redirect
 
 ## Useful Patterns
 
@@ -359,10 +383,21 @@ await saveTestResult(questions, answers);
 await saveRandomAttempt(question, selectedAnswer);
 ```
 
-### Protected Routes
-```typescript
-const { user, loading } = useAuth();
+### Route Protection
 
+**Fully protected** (redirect guests to `/auth`):
+```typescript
+// Admin and other auth-only pages
+const { user, loading } = useAuth();
 if (loading) return <PageLoader />;
 if (!user) return <Navigate to="/auth" />;
 ```
+
+**Guest-accessible** (Dashboard pattern — `!user` means guest, not redirect):
+```typescript
+// Dashboard allows guests; data-dependent sections show placeholders
+const { user } = useAuth();
+if (!user) return <GuestView />;  // render placeholder, don't redirect
+```
+
+`/admin` is fully protected. `/dashboard` and all study modes are guest-accessible.

--- a/docs/superpowers/plans/2026-05-20-guest-mode-unified-ui.md
+++ b/docs/superpowers/plans/2026-05-20-guest-mode-unified-ui.md
@@ -1,0 +1,614 @@
+# Guest Mode: Unified UI — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the separate guest dashboard with the real authenticated UI — guests see the same chrome and layout as logged-in users, with empty states handling the difference.
+
+**Architecture:** Remove AppLayout's `!user` early return so the full sidebar renders for everyone. Sidebar adapts when `userId` is undefined (disabled auth-gated items, "Sign in →" footer). Delete the ~115-line guest dashboard block from Dashboard.tsx and move the guest banner into the main render. Four focused changes, one commit each.
+
+**Tech Stack:** React 18, TypeScript, Tailwind CSS, shadcn/ui, TanStack Query, Vitest
+
+---
+
+## File Map
+
+| File | What changes |
+|---|---|
+| `src/components/AppLayout.tsx` | Remove 3-line guest early return; make `userInfo` conditional on `!!user` |
+| `src/components/sidebar/SidebarFooter.tsx` | Add "Sign in →" guest branch when `!userInfo` |
+| `src/components/DashboardSidebar.tsx` | Add `disabled: !userId` to `bookmarks` nav item |
+| `src/pages/Dashboard.tsx` | Delete ~115-line guest block; move banner into main render; remove orphaned imports |
+| `src/pages/Dashboard.test.tsx` | Update guest mode test assertion to match new render |
+
+---
+
+## Task 1: AppLayout — Remove Guest Early Return
+
+**Files:**
+- Modify: `src/components/AppLayout.tsx`
+
+- [ ] **Step 1: Read the file**
+
+Open `src/components/AppLayout.tsx`. Locate the block at lines 79–81:
+```typescript
+if (!user) {
+  return <>{children}</>;
+}
+```
+And the `userInfo` assignment below it (around line 83–87):
+```typescript
+const userInfo = {
+  displayName: profile?.display_name || null,
+  email: user.email || null,
+  forumUsername: profile?.forum_username || null,
+};
+```
+
+- [ ] **Step 2: Delete the guest early return and fix userInfo**
+
+Replace both blocks so guests get the sidebar and `userInfo` is safe when `user` is null:
+
+```typescript
+// Remove the three-line if (!user) block entirely.
+
+// Change the userInfo assignment to:
+const userInfo = user ? {
+  displayName: profile?.display_name || null,
+  email: user.email || null,
+  forumUsername: profile?.forum_username || null,
+} : undefined;
+```
+
+`DashboardSidebar` already accepts `userInfo?: UserInfo` and `userId?: string` — passing `undefined` is safe.
+
+Also update the `DashboardSidebar` call to pass `userId={user?.id}` and `onProfileUpdate={user ? handleProfileUpdate : undefined}` (find these props in the `<DashboardSidebar ... />` JSX below and adjust):
+
+```tsx
+<DashboardSidebar
+  currentView={currentView}
+  onViewChange={onViewChange}
+  onSignOut={handleSignOut}
+  isCollapsed={sidebarCollapsed}
+  onToggleCollapse={() => setSidebarCollapsed(!sidebarCollapsed)}
+  weakQuestionCount={weakQuestionIds.length}
+  bookmarkCount={filteredBookmarks.length}
+  isTestAvailable={isTestAvailable}
+  userInfo={userInfo}
+  userId={user?.id}
+  onProfileUpdate={user ? handleProfileUpdate : undefined}
+  selectedTest={selectedTest}
+  onTestChange={onTestChange}
+  onSearch={onSearch}
+/>
+```
+
+- [ ] **Step 3: Run the test suite to verify nothing breaks**
+
+```bash
+npm run test:run -- --reporter=verbose 2>&1 | tail -30
+```
+
+Expected: all existing tests pass. The only behavioral change so far is that guests now get the sidebar rendered — visual in-browser verification comes in a later task.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/AppLayout.tsx
+git commit -m "feat: show sidebar for guest users in AppLayout"
+```
+
+---
+
+## Task 2: SidebarFooter — Guest Sign-In State
+
+**Files:**
+- Modify: `src/components/sidebar/SidebarFooter.tsx`
+- Test: `src/components/sidebar/SidebarFooter.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Open (or create) `src/components/sidebar/SidebarFooter.test.tsx`. Add this test:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { SidebarFooter } from './SidebarFooter';
+
+// SidebarFooter uses useAdmin internally
+vi.mock('@/hooks/useAdmin', () => ({ useAdmin: () => ({ isAdmin: false }) }));
+
+describe('SidebarFooter', () => {
+  const baseProps = {
+    isAdmin: false,
+    isOnAdminPage: false,
+    isCollapsed: false,
+    isMobile: false,
+    onProfileClick: vi.fn(),
+    onAdminClick: vi.fn(),
+  };
+
+  it('shows Sign in link when userInfo is undefined', () => {
+    render(<SidebarFooter {...baseProps} userInfo={undefined} />);
+    expect(screen.getByRole('link', { name: /sign in/i })).toHaveAttribute('href', '/auth');
+  });
+
+  it('shows user profile button when userInfo is provided', () => {
+    render(
+      <SidebarFooter
+        {...baseProps}
+        userInfo={{ displayName: 'Ada Lovelace', email: 'ada@example.com', forumUsername: null }}
+      />
+    );
+    expect(screen.getByText('Ada Lovelace')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /sign in/i })).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npx vitest run src/components/sidebar/SidebarFooter.test.tsx --reporter=verbose
+```
+
+Expected: FAIL — "Sign in link when userInfo is undefined" fails because the component currently shows a profile button with "U" initials instead.
+
+- [ ] **Step 3: Add the guest branch to SidebarFooter**
+
+Open `src/components/sidebar/SidebarFooter.tsx`. In the `SidebarFooter` function, add a guest branch at the top of the returned JSX, just before the user profile section. The `SidebarFooter` currently renders an outer `<div className="border-t border-border">`. Replace the entire component body with:
+
+```tsx
+export function SidebarFooter({
+  userInfo,
+  isAdmin,
+  isOnAdminPage,
+  isCollapsed,
+  isMobile,
+  onProfileClick,
+  onAdminClick,
+}: SidebarFooterProps) {
+  const showExpanded = isMobile || !isCollapsed;
+
+  const getInitials = () => {
+    if (userInfo?.displayName) {
+      return userInfo.displayName
+        .split(' ')
+        .map((n) => n[0])
+        .join('')
+        .toUpperCase()
+        .slice(0, 2);
+    }
+    if (userInfo?.email) {
+      return userInfo.email[0].toUpperCase();
+    }
+    return 'U';
+  };
+
+  return (
+    <div className="border-t border-border">
+      {/* Admin Link */}
+      {isAdmin && (
+        <div
+          className={cn(
+            'p-2 border-b border-border',
+            !isMobile && isCollapsed && 'flex justify-center'
+          )}
+        >
+          {!showExpanded ? (
+            <Tooltip delayDuration={0}>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={onAdminClick}
+                  className={cn(
+                    'w-full h-10',
+                    isOnAdminPage
+                      ? 'text-primary bg-primary/10'
+                      : 'text-muted-foreground hover:text-primary'
+                  )}
+                >
+                  <Shield className="w-5 h-5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="right" className="bg-popover border-border">
+                <p>Admin Dashboard</p>
+              </TooltipContent>
+            </Tooltip>
+          ) : (
+            <Button
+              variant="ghost"
+              onClick={onAdminClick}
+              className={cn(
+                'w-full justify-start gap-3',
+                isOnAdminPage
+                  ? 'text-primary bg-primary/10'
+                  : 'text-muted-foreground hover:text-primary'
+              )}
+            >
+              <Shield className="w-5 h-5" />
+              <span className="text-base font-medium">Admin</span>
+            </Button>
+          )}
+        </div>
+      )}
+
+      {/* Guest: Sign in link */}
+      {!userInfo && (
+        <div className="p-3">
+          <a
+            href="/auth"
+            className="text-sm font-medium text-primary hover:underline"
+          >
+            Sign in →
+          </a>
+        </div>
+      )}
+
+      {/* Authenticated: User Profile Section */}
+      {userInfo && (
+        <div
+          className={cn(
+            'p-3',
+            !isMobile && isCollapsed && 'flex justify-center'
+          )}
+        >
+          {showExpanded ? (
+            <button
+              onClick={onProfileClick}
+              className="w-full flex items-center gap-3 p-2 -m-2 rounded-lg hover:bg-secondary transition-colors"
+            >
+              <Avatar className="h-9 w-9 shrink-0">
+                <AvatarFallback className="bg-primary/10 text-primary text-sm font-medium">
+                  {getInitials()}
+                </AvatarFallback>
+              </Avatar>
+              <div className="flex-1 min-w-0 text-left">
+                <p className="text-sm font-medium text-foreground truncate">
+                  {userInfo.displayName || 'User'}
+                </p>
+                <p className="text-sm text-muted-foreground truncate">
+                  {userInfo.email || ''}
+                </p>
+              </div>
+            </button>
+          ) : (
+            <Tooltip delayDuration={0}>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={onProfileClick}
+                  className="rounded-full hover:ring-2 hover:ring-primary/20 transition-all"
+                >
+                  <Avatar className="h-8 w-8 cursor-pointer">
+                    <AvatarFallback className="bg-primary/10 text-primary text-xs font-medium">
+                      {getInitials()}
+                    </AvatarFallback>
+                  </Avatar>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="right" className="bg-popover border-border">
+                <p className="font-medium">{userInfo.displayName || 'User'}</p>
+                <p className="text-xs text-muted-foreground">{userInfo.email}</p>
+              </TooltipContent>
+            </Tooltip>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+npx vitest run src/components/sidebar/SidebarFooter.test.tsx --reporter=verbose
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 5: Run full suite to check for regressions**
+
+```bash
+npm run test:run 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/sidebar/SidebarFooter.tsx src/components/sidebar/SidebarFooter.test.tsx
+git commit -m "feat: show Sign in link in sidebar footer for guests"
+```
+
+---
+
+## Task 3: DashboardSidebar — Disable Bookmarks for Guests
+
+**Files:**
+- Modify: `src/components/DashboardSidebar.tsx`
+
+The `weakQuestionCount` is already `0` for guests (query disabled → empty data), and the item already has `disabled: !isTestAvailable || weakQuestionCount === 0` — so it is naturally disabled. Only `bookmarks` needs an explicit guest guard.
+
+- [ ] **Step 1: Add disabled condition to the bookmarks nav item**
+
+In `src/components/DashboardSidebar.tsx`, find the `studyGroup` definition and locate the `bookmarks` item:
+
+```typescript
+{ id: 'bookmarks', label: 'Bookmarked', icon: Bookmark, badge: bookmarkCount, badgeAriaLabel: bookmarkCount === 1 ? '1 bookmark' : `${bookmarkCount} bookmarks` },
+```
+
+Replace it with:
+
+```typescript
+{ id: 'bookmarks', label: 'Bookmarked', icon: Bookmark, badge: userId ? bookmarkCount : undefined, badgeAriaLabel: bookmarkCount === 1 ? '1 bookmark' : `${bookmarkCount} bookmarks`, disabled: !userId },
+```
+
+This disables the item and suppresses the badge when there is no authenticated user.
+
+- [ ] **Step 2: Run the test suite**
+
+```bash
+npm run test:run 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/DashboardSidebar.tsx
+git commit -m "feat: disable bookmarks nav item for unauthenticated users"
+```
+
+---
+
+## Task 4: Dashboard.tsx — Delete Guest Block, Move Banner
+
+**Files:**
+- Modify: `src/pages/Dashboard.tsx`
+
+- [ ] **Step 1: Remove orphaned lucide imports**
+
+In `src/pages/Dashboard.tsx`, find the import line that includes `BookOpen`, `Shuffle`, `GraduationCap`, `BookMarked` (added in the original PR for the guest-only study mode cards). Remove only those four from the import:
+
+```typescript
+// Before
+import { Loader2, AlertTriangle, Zap, Brain, Target, MapPin, BookOpen, Shuffle, GraduationCap, BookMarked } from 'lucide-react';
+
+// After
+import { Loader2, AlertTriangle, Zap, Brain, Target, MapPin } from 'lucide-react';
+```
+
+- [ ] **Step 2: Delete the entire guest dashboard block**
+
+In `renderContent()`, find and delete the entire block starting at `if (!user) {` and ending at the matching `}` (approximately 115 lines). It starts just after the `authLoading` loading check and ends before `// Calculate weekly goal progress`.
+
+The block to delete looks like this (condensed to show start/end):
+
+```typescript
+// DELETE FROM HERE:
+if (!user) {
+  return (
+    <PageContainer width="standard" radioWaveBg>
+      {!guestBannerDismissed && (
+        // ... guest banner ...
+      )}
+      // ... guest study mode cards ...
+      // ... guest placeholder sections ...
+    </PageContainer>
+  );
+}
+// TO HERE (inclusive of the closing brace)
+```
+
+After deletion, `renderContent()` should flow from the loading check directly to `// Calculate weekly goal progress`.
+
+- [ ] **Step 3: Move the guest banner into the main dashboard render**
+
+The main dashboard `return` starts at `return (` and the first child is `<PageContainer width="standard" radioWaveBg>`. Inside that, the first rendered component is `<DashboardHero .../>`.
+
+Add the guest banner as the first child inside `<PageContainer>`, before `<DashboardHero>`:
+
+```tsx
+return (
+  <PageContainer width="standard" radioWaveBg>
+    {/* Guest banner — shown to unauthenticated users, dismissible */}
+    {!user && !guestBannerDismissed && (
+      <div className="flex items-center justify-between gap-3 bg-primary/10 border border-primary/20 rounded-lg px-4 py-3 mb-6">
+        <p className="text-sm text-foreground">
+          You're studying as a guest — progress isn't being saved.{' '}
+          <a href="/auth" className="text-primary hover:underline font-medium">
+            Create a free account
+          </a>
+        </p>
+        <button
+          onClick={() => {
+            localStorage.setItem('guest_banner_dismissed', 'true');
+            setGuestBannerDismissed(true);
+          }}
+          aria-label="Dismiss banner"
+          className="text-muted-foreground hover:text-foreground transition-colors flex-shrink-0"
+        >
+          ✕
+        </button>
+      </div>
+    )}
+
+    <DashboardHero
+      readinessLevel={readinessLevel}
+      readinessTitle={readinessTitle}
+      readinessMessage={readinessMessage}
+      recentAvgScore={recentAvgScore}
+      nextAction={nextAction}
+      onAction={handlePrimaryAction}
+    />
+
+    <DashboardNotifications
+      examType={selectedTest}
+      userId={user?.id}
+      thisWeekQuestions={thisWeekQuestions}
+      questionsGoal={questionsGoal}
+      userTarget={userTarget}
+      onNavigate={changeView}
+      maxVisible={1}
+    />
+
+    <div className="mb-6">
+      <StreakDisplay onAction={() => changeView('random-practice')} />
+    </div>
+
+    <DashboardNextSteps steps={getNextSteps()} />
+
+    <DashboardSectionInsights
+      subelementMetrics={readinessData?.subelement_metrics}
+      testType={selectedTest}
+      onPracticeSection={navigateToSubelementPractice}
+    />
+
+    <DashboardProgress
+      thisWeekQuestions={thisWeekQuestions}
+      questionsGoal={questionsGoal}
+      thisWeekTests={thisWeekTests}
+      testsGoal={testsGoal}
+      examDate={userTarget?.exam_session?.exam_date || userTarget?.custom_exam_date}
+      examLocation={
+        userTarget?.exam_session
+          ? `${userTarget.exam_session.city}, ${userTarget.exam_session.state}`
+          : userTarget?.custom_exam_date
+            ? 'Custom date'
+            : undefined
+      }
+      onOpenGoalsModal={() => setShowGoalsModal(true)}
+      onFindTestSite={() => changeView('find-test-site')}
+    />
+  </PageContainer>
+);
+```
+
+Keep `guestBannerDismissed` state and its `localStorage` initialization exactly as-is in the component.
+
+- [ ] **Step 4: Run the test suite**
+
+```bash
+npm run test:run 2>&1 | tail -20
+```
+
+Expected: most tests pass; `Dashboard.test.tsx` guest mode test will fail because it still looks for 'Start Studying' from the deleted block. That is expected — fix it in Task 5.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pages/Dashboard.tsx
+git commit -m "feat: remove separate guest dashboard, guests now use main dashboard"
+```
+
+---
+
+## Task 5: Update Dashboard Test
+
+**Files:**
+- Modify: `src/pages/Dashboard.test.tsx`
+
+- [ ] **Step 1: Find and read the failing guest mode test**
+
+In `src/pages/Dashboard.test.tsx`, find the `describe('Guest mode', ...)` block. It currently looks like:
+
+```typescript
+describe('Guest mode', () => {
+  it('shows guest dashboard (not redirect) when user is not authenticated', async () => {
+    mockAuthHook.mockReturnValueOnce({
+      user: null,
+      loading: false,
+      signOut: vi.fn(),
+    });
+
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Start Studying')).toBeInTheDocument();
+    });
+    expect(mockNavigate).not.toHaveBeenCalledWith('/auth');
+  });
+});
+```
+
+`'Start Studying'` was in the deleted guest block. It no longer renders.
+
+- [ ] **Step 2: Update the assertion to match the new render**
+
+The new guest dashboard renders the full main dashboard. The guest banner reads "You're studying as a guest". Replace the test:
+
+```typescript
+describe('Guest mode', () => {
+  it('renders main dashboard (not a redirect) when user is not authenticated', async () => {
+    mockAuthHook.mockReturnValueOnce({
+      user: null,
+      loading: false,
+      signOut: vi.fn(),
+    });
+
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText(/you're studying as a guest/i)).toBeInTheDocument();
+    });
+    expect(mockNavigate).not.toHaveBeenCalledWith('/auth');
+  });
+});
+```
+
+- [ ] **Step 3: Run just the Dashboard test to verify it passes**
+
+```bash
+npx vitest run src/pages/Dashboard.test.tsx --reporter=verbose
+```
+
+Expected: all tests in this file PASS.
+
+- [ ] **Step 4: Run the full test suite**
+
+```bash
+npm run test:run 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pages/Dashboard.test.tsx
+git commit -m "test: update guest mode test to match unified dashboard"
+```
+
+---
+
+## Task 6: Manual Verification
+
+These checks cannot be covered by unit tests — run the dev server and verify in browser.
+
+- [ ] **Step 1: Start the dev server**
+
+```bash
+npm run dev
+```
+
+- [ ] **Step 2: Verify guest flow end-to-end**
+
+Open `http://localhost:8080` in an incognito/private window (ensures no cached auth).
+
+1. `http://localhost:8080` → should land on `/auth`
+2. Click "Continue as guest" → should land on `/dashboard` **with the full sidebar visible**
+3. Sidebar: Practice Test, Random Practice, Topics, Glossary — all clickable and functional
+4. Sidebar: Bookmarks and Weak Areas — visible but greyed out / non-clickable
+5. Sidebar footer: shows "Sign in →" link (not a user profile)
+6. Guest banner at top of dashboard — visible, dismisses on ✕, does not reappear on refresh (localStorage key `guest_banner_dismissed`)
+7. Click "Practice Test" in sidebar → navigates into PracticeTest; sidebar still visible; clicking "Dashboard" in sidebar returns to dashboard
+8. Same for Random Practice, Topics, Glossary
+9. Complete a practice test as guest → inline save card appears below score
+10. Sign in from any "Sign in →" link → authenticated user sees full dashboard with profile in sidebar footer
+
+- [ ] **Step 3: Commit any fixes found during verification**
+
+If step 2 reveals broken behavior, fix it and commit before marking this task done.

--- a/docs/superpowers/specs/2026-05-20-guest-mode-design.md
+++ b/docs/superpowers/specs/2026-05-20-guest-mode-design.md
@@ -1,0 +1,181 @@
+# Guest Mode Design
+
+**Date:** 2026-05-20  
+**Status:** Approved
+
+## Context
+
+Users are abandoning the app before trying it because they're required to create an account before seeing any content. The ask: let anyone walk into the app, use every study mode, and experience the product without signing up. Progress simply doesn't get saved, and the app is transparent about why — not pushy about converting.
+
+The core principle: **feature-honest framing, not sales pressure.** Every sign-up nudge explains what an account enables technically, not why the user should "unlock" something.
+
+---
+
+## Approach: Progressive Auth Prompts
+
+Guests access the full app. Auth prompts appear inline at meaningful save moments. The app earns the ask rather than front-loading friction.
+
+---
+
+## 1. Entry & Routing
+
+**Current behavior:** `Index.tsx` redirects unauthenticated users to `/auth`, which has no escape — users must create an account to proceed.
+
+**New behavior:**
+- `Index.tsx` keeps its existing logic: authenticated users → `/dashboard`, unauthenticated → `/auth`
+- `/auth` page gains a **"Continue as guest"** option (see Section 2)
+- `/dashboard` removes its auth redirect guard — `!user` means guest mode, not a redirect
+- `/admin` stays fully protected, no change
+
+**Files to modify:**
+- `src/pages/Auth.tsx` — add guest entry point
+- `src/pages/Dashboard.tsx` — remove auth redirect (lines 130-134)
+
+---
+
+## 2. Auth Page: Guest Entry Point
+
+A "Continue as guest" option is added **below** the existing sign-in form and Google button, separated by a divider. It uses a dashed border to visually signal it's a secondary path.
+
+**Layout:**
+```
+[Sign in form]
+[Continue with Google]
+────── or ──────
+┌ - - - - - - - - - - - - - - - ┐
+  Continue as guest →
+  Progress won't be saved
+└ - - - - - - - - - - - - - - - ┘
+```
+
+**Behavior:** Clicking it navigates to `/dashboard`. No session is created, no backend calls are made. The user is now in guest mode.
+
+**File to modify:** `src/pages/Auth.tsx`
+
+---
+
+## 3. Dashboard: Guest State
+
+### What works for guests (no auth needed)
+All study mode action cards render and function normally:
+- Practice Test
+- Random Practice
+- Study by Topic
+- Glossary
+
+These work because `useQuestions` has no auth requirement — questions are public data.
+
+### What requires an account (data-dependent sections)
+The following sections replace their content with a **feature-honest placeholder** when `!user`:
+- Readiness score / psychometrics
+- Streak counter
+- Weak questions
+- Recent test results
+- Bookmarks widget
+
+**Placeholder pattern (copy principle):**
+> *"[Feature name] requires an account because [honest technical reason]."*
+
+Examples:
+- *"Tracking your progress over time requires an account — there's nowhere to save it without one."*
+- *"Identifying weak areas requires a history of your answers, which needs an account."*
+- *"Bookmarks need an account to persist — otherwise they disappear when you close the tab."*
+
+Each placeholder includes a **"Create free account"** link — not a button styled like a CTA, just a link. Tone: informational, not promotional.
+
+### Why no backend calls fire
+All user-scoped TanStack Query hooks already use `enabled: !!user`. When `user` is null, the queries never execute — no requests, no errors, no broken states. This pattern is documented in `src/services/queryKeys.ts` and used consistently across all hooks in `src/hooks/`.
+
+### Dismissible top banner
+A one-time blue info banner appears at the top of the dashboard for all guest sessions:
+
+> *"You're studying as a guest — progress isn't being saved. [Create a free account](link) to save your results."*
+
+Dismissible via ✕. Dismissed state stored in `localStorage` so it doesn't reappear on refresh.
+
+**File to modify:** `src/pages/Dashboard.tsx` and the relevant dashboard section components
+
+---
+
+## 4. Progressive Auth Prompts (Save Moments)
+
+Auth prompts appear at three specific save moments. All are dismissible and non-blocking.
+
+### 4a. After completing a practice test
+An inline card renders **below the score** on the test results screen.
+
+**Copy:** *"Test results require an account to save — there's nowhere to put them without one."*
+
+**Actions:**
+- `Create free account` (links to `/auth?returnTo=/dashboard`)
+- `Continue without saving` (dismisses the card)
+
+The score and full results are always visible — the card is additive, never a gate.
+
+**File to modify:** `src/components/PracticeTest.tsx`
+
+### 4b. Clicking a bookmark icon
+A small tooltip/popover appears on the bookmark icon instead of triggering a save.
+
+**Copy:** *"Bookmarks need an account to persist — they'd disappear when you close the tab."*
+
+**Actions:**
+- `Create free account` link
+- Tooltip dismisses on click-away
+
+**Files to modify:** bookmark icon component(s) in `src/components/`
+
+### 4c. Random practice session end
+A Sonner toast appears using the existing toast pattern.
+
+**Copy:** *"Your practice session wasn't saved — create a free account to track your progress."*
+
+No action button — just the message with a link. Uses the existing `toast()` call pattern from `src/hooks/use-toast.ts`.
+
+**File to modify:** `src/components/RandomPractice.tsx`
+
+---
+
+## 5. Copy Principles (Global)
+
+All guest-facing copy follows this rule: **explain what an account enables technically, not why the user should want to sign up.**
+
+| ❌ Don't write | ✓ Write instead |
+|---|---|
+| "Sign up to unlock your stats" | "Stats require an account — there's nowhere to store them without one" |
+| "Create an account to get started" | "Continue as guest" (on auth page) |
+| "You're missing out on features" | "This feature tracks X over time, which needs an account" |
+| "Sign up free — it only takes a second" | "Create a free account" (plain link, no pressure) |
+
+---
+
+## 6. Scope Boundaries
+
+**In scope:**
+- Auth page guest entry point
+- Dashboard auth guard removal + guest placeholders
+- Dismissible guest banner
+- Post-test inline save card
+- Bookmark guest tooltip
+- Random practice guest toast
+
+**Out of scope (no change needed):**
+- `useProgress` save operations already return early on `!user` — no changes needed
+- `progressService.requireUserId()` already handles unauthenticated gracefully
+- All user-scoped query hooks already have `enabled: !!user` — no changes needed
+- `/admin` route — stays protected
+
+---
+
+## 7. Verification
+
+1. Visit `/` without being logged in → should land on `/auth`
+2. Click "Continue as guest" → should land on `/dashboard`
+3. Guest banner appears at top of dashboard, dismisses on ✕, doesn't reappear on refresh
+4. All study mode cards are clickable and launch their respective modes
+5. Data-dependent sections (readiness, streaks, weak questions) show placeholder copy, not errors or empty states
+6. Complete a practice test as guest → inline save card appears below score, results are fully visible
+7. Click a bookmark icon as guest → tooltip appears, no save attempt made, no console errors
+8. Complete a random practice session as guest → toast notification appears
+9. Sign in from any "Create free account" link → `returnTo` param returns user to the correct page after auth
+10. Verify no Supabase API calls are made for user-scoped data while in guest mode (Network tab)

--- a/docs/superpowers/specs/2026-05-20-guest-mode-unified-ui.md
+++ b/docs/superpowers/specs/2026-05-20-guest-mode-unified-ui.md
@@ -1,0 +1,145 @@
+# Guest Mode: Unified UI
+
+**Date:** 2026-05-20
+**Status:** Approved
+
+## Context
+
+The initial guest mode implementation created a completely separate guest dashboard (a ~115-line `if (!user)` branch in `Dashboard.tsx`). This means every future change to the real dashboard must be made in two places. It also strips the sidebar from guests entirely (`AppLayout` returns bare `<>{children}</>` for unauthenticated users), which leaves guests with no navigation once they enter a study mode.
+
+The fix: guests see the same UI as authenticated users. Empty states handle the difference. One UI to maintain.
+
+---
+
+## 1. AppLayout — Show Sidebar for Guests
+
+**File:** `src/components/AppLayout.tsx`
+
+Remove the early return at lines 79–81:
+
+```typescript
+// DELETE THIS
+if (!user) {
+  return <>{children}</>;
+}
+```
+
+Guests now receive the full sidebar/nav wrapper. The `DashboardSidebar` already reads `useAuth` internally for user-specific data — the only change needed is how it renders when `!user` (see Section 2).
+
+---
+
+## 2. DashboardSidebar — Greyed Auth-Gated Items
+
+**File:** `src/components/DashboardSidebar.tsx` (and relevant sidebar sub-components)
+
+When `!user`:
+
+- **Bookmarks** nav item: renders at reduced opacity (`opacity-40`), no count badge, `disabled` (pointer-events none or `onClick` suppressed). Do not navigate — clicking does nothing.
+- **Weak Questions** nav item: same treatment — visible but muted, no count badge, disabled.
+- **User profile footer**: `DashboardSidebar` already guards the profile block with `{userId && userInfo && onProfileUpdate && (...)}` (line 309). When `AppLayout` passes `userId={undefined}` for guests, that block doesn't render. Add a fallback directly below it: a `Sign in →` link to `/auth` that only renders when `!userId`.
+- All other nav items (Practice Test, Random Practice, Topics, Glossary, Find Test Site, Tools): unchanged — fully functional for guests.
+
+The sidebar receives `weakQuestionCount` and `bookmarkCount` as props from `AppLayout`. Those are already derived from hooks that use `enabled: !!user`, so they'll be `0`/empty for guests — no special casing needed for the counts themselves, just suppress the badge render when the count is `0` and `!user`.
+
+---
+
+## 3. Dashboard.tsx — Delete Guest Block, Add Empty States
+
+**File:** `src/pages/Dashboard.tsx`
+
+### 3a. Delete the guest block
+
+Remove the entire `if (!user) { return (<PageContainer>...</PageContainer>) }` block (~115 lines, starting around line 308). The dashboard renders for everyone.
+
+Also remove these imports that are only used in the deleted block:
+- `BookOpen`, `Shuffle`, `GraduationCap`, `BookMarked` from `lucide-react` (added in the original PR for the guest-only cards)
+
+### 3b. Keep the guest banner
+
+The dismissible blue guest banner stays. Move it from the deleted guest block into the top of the main dashboard render (inside the authenticated section, guarded by `!user`):
+
+```tsx
+{!user && !guestBannerDismissed && (
+  <div className="flex items-center justify-between gap-3 bg-primary/10 border border-primary/20 rounded-lg px-4 py-3 mb-6">
+    <p className="text-sm text-foreground">
+      You're studying as a guest — progress isn't being saved.{' '}
+      <a href="/auth" className="text-primary hover:underline font-medium">
+        Create a free account
+      </a>
+    </p>
+    <button
+      onClick={() => {
+        localStorage.setItem('guest_banner_dismissed', 'true');
+        setGuestBannerDismissed(true);
+      }}
+      aria-label="Dismiss banner"
+      className="text-muted-foreground hover:text-foreground transition-colors flex-shrink-0"
+    >
+      ✕
+    </button>
+  </div>
+)}
+```
+
+The `guestBannerDismissed` state and `localStorage` logic stays as-is.
+
+### 3c. Empty states for data-dependent sections
+
+Each section that depends on user data already has `enabled: !!user` on its query, so it returns `undefined`/empty for guests. Replace any spinner-only or null fallbacks with the **Empty State** pattern:
+
+**Pattern:** Real widget structure, dashes/flat bars where numbers would go, `Sign in →` link at the bottom.
+
+Apply to these sections (identify each by its current loading/empty handling):
+- **Readiness Score**: show `—%`, flat progress bar, `Sign in →`
+- **Streak**: show `—` day streak, `Sign in →`
+- **Weak Questions**: show `0 weak questions` placeholder or `—`, `Sign in →`
+- **Recent Tests**: show the section header + an empty state message ("No tests recorded yet — sign in to save results"), `Sign in →`
+- **Bookmarks widget**: show `—` bookmarks, `Sign in →`
+
+Each `Sign in →` links to `/auth`.
+
+---
+
+## 4. Back Navigation — Solved for Free
+
+Once guests have the sidebar, navigating back from any study mode works identically to the authenticated experience — via the sidebar nav. No changes needed to `PracticeTest`, `RandomPractice`, or any other study mode component.
+
+---
+
+## 5. What Stays Unchanged
+
+These pieces from the original guest mode PR are correct and stay as-is:
+
+- `src/components/TestResults.tsx` — inline save card for guests after completing a test
+- `src/components/QuestionCard.tsx` — guest bookmark popover
+- `src/components/RandomPractice.tsx` — guest toast on session end
+- `src/pages/Auth.tsx` — "Continue as guest" entry point
+- `src/pages/Dashboard.test.tsx` — guest mode test (may need minor update to reflect new render path)
+- `src/components/TestResults.test.tsx` — no changes needed
+
+---
+
+## 6. Files to Modify
+
+| File | Change |
+|---|---|
+| `src/components/AppLayout.tsx` | Remove guest early return (3 lines) |
+| `src/components/DashboardSidebar.tsx` | Mute Bookmarks + Weak Questions when `!user`; swap profile footer for Sign in link |
+| `src/components/sidebar/SidebarNavItem.tsx` (or equivalent) | Support disabled/muted state for locked items |
+| `src/pages/Dashboard.tsx` | Delete guest block; add banner + empty states to main render |
+
+---
+
+## 7. Verification
+
+1. Visit `/` unauthenticated → lands on `/auth`
+2. Click "Continue as guest" → lands on `/dashboard` with full sidebar visible
+3. Sidebar shows Practice Test, Random Practice, Topics, Glossary as active nav items
+4. Bookmarks and Weak Questions are visible in sidebar but muted (no count, non-clickable)
+5. Sidebar footer shows "Sign in →" instead of user profile
+6. Guest banner appears at top of dashboard, dismisses on ✕, doesn't reappear on refresh
+7. Readiness Score, Streak, Weak Questions, Recent Tests, Bookmarks widgets all show empty states with "Sign in →" — not spinners, not broken
+8. Click "Practice Test" → navigates into PracticeTest; sidebar is present; clicking "Dashboard" in sidebar returns to dashboard
+9. Same for Random Practice, Topics, Glossary
+10. Sign in from any "Sign in →" or "Create free account" link → returns to dashboard as authenticated user; sidebar now shows full user profile and counts
+11. No Supabase API calls for user-scoped data while in guest mode (Network tab)

--- a/src/components/AppLayout.test.tsx
+++ b/src/components/AppLayout.test.tsx
@@ -142,7 +142,7 @@ describe('AppLayout', () => {
   });
 
   describe('Unauthenticated State', () => {
-    it('renders children without sidebar when user is not authenticated', () => {
+    it('renders children with sidebar when user is not authenticated', async () => {
       mockUseAuth.mockReturnValue({
         user: null,
         loading: false,
@@ -157,8 +157,10 @@ describe('AppLayout', () => {
       );
 
       expect(screen.getByText('Child Content')).toBeInTheDocument();
-      // Sidebar should not be rendered
-      expect(screen.queryByText('Dashboard')).not.toBeInTheDocument();
+      // Sidebar should be rendered for guests too
+      await waitFor(() => {
+        expect(screen.getByText('Dashboard')).toBeInTheDocument();
+      });
     });
   });
 

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -76,15 +76,11 @@ export function AppLayout({ children, currentView, onViewChange, selectedTest, o
     );
   }
 
-  if (!user) {
-    return <>{children}</>;
-  }
-
-  const userInfo = {
+  const userInfo = user ? {
     displayName: profile?.display_name || null,
     email: user.email || null,
     forumUsername: profile?.forum_username || null,
-  };
+  } : undefined;
 
   const currentTest = testTypes.find(t => t.id === selectedTest);
   const isTestAvailable = currentTest?.available ?? false;
@@ -103,8 +99,8 @@ export function AppLayout({ children, currentView, onViewChange, selectedTest, o
           bookmarkCount={filteredBookmarks.length}
           isTestAvailable={isTestAvailable}
           userInfo={userInfo}
-          userId={user.id}
-          onProfileUpdate={handleProfileUpdate}
+          userId={user?.id}
+          onProfileUpdate={user ? handleProfileUpdate : undefined}
           selectedTest={selectedTest}
           onTestChange={onTestChange}
           onSearch={onSearch}

--- a/src/components/DashboardSidebar.tsx
+++ b/src/components/DashboardSidebar.tsx
@@ -124,7 +124,7 @@ export function DashboardSidebar({
         badgeAriaLabel: weakQuestionCount === 1 ? '1 weak question' : `${weakQuestionCount} weak questions`,
         disabled: !isTestAvailable || weakQuestionCount === 0,
       },
-      { id: 'bookmarks', label: 'Bookmarked', icon: Bookmark, badge: bookmarkCount, badgeAriaLabel: bookmarkCount === 1 ? '1 bookmark' : `${bookmarkCount} bookmarks` },
+      { id: 'bookmarks', label: 'Bookmarked', icon: Bookmark, badge: userId ? bookmarkCount : undefined, badgeAriaLabel: bookmarkCount === 1 ? '1 bookmark' : `${bookmarkCount} bookmarks`, disabled: !userId },
       { id: 'glossary-flashcards', label: 'Flashcards', icon: Square },
     ],
   };

--- a/src/components/QuestionCard.test.tsx
+++ b/src/components/QuestionCard.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { QuestionCard } from './QuestionCard';
 import { Question } from '@/hooks/useQuestions';
 import { TooltipProvider } from '@/components/ui/tooltip';
@@ -79,14 +80,16 @@ const mockQuestion: Question = {
 
 const renderQuestionCard = (props: Partial<Parameters<typeof QuestionCard>[0]> = {}) => {
   return render(
-    <TooltipProvider>
-      <QuestionCard
-        question={mockQuestion}
-        selectedAnswer={null}
-        onSelectAnswer={vi.fn()}
-        {...props}
-      />
-    </TooltipProvider>
+    <MemoryRouter>
+      <TooltipProvider>
+        <QuestionCard
+          question={mockQuestion}
+          selectedAnswer={null}
+          onSelectAnswer={vi.fn()}
+          {...props}
+        />
+      </TooltipProvider>
+    </MemoryRouter>
   );
 };
 
@@ -397,6 +400,33 @@ describe('QuestionCard', () => {
 
       const linkButton = screen.queryByRole('button', { name: /copy shareable link/i });
       expect(linkButton).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Guest bookmark popover', () => {
+    // Default mock has user: null, so guest floating actions render
+    it('shows bookmark prompt with sign-up link when bookmark icon is clicked', () => {
+      renderQuestionCard();
+
+      fireEvent.click(screen.getByRole('button', { name: /bookmark this question/i }));
+
+      expect(
+        screen.getByText(/bookmarks need an account to persist/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', { name: /create free account/i })
+      ).toHaveAttribute('href', '/auth');
+    });
+
+    it('does not call addBookmark when guest clicks the bookmark icon', () => {
+      // The useBookmarks mock returns a vi.fn() for addBookmark.mutate.
+      // Guests should never trigger a save attempt — the click opens the prompt instead.
+      renderQuestionCard();
+
+      fireEvent.click(screen.getByRole('button', { name: /bookmark this question/i }));
+
+      // No toast.success was called (which would happen on a successful save path).
+      expect(mockToastSuccess).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/QuestionCard.test.tsx
+++ b/src/components/QuestionCard.test.tsx
@@ -415,7 +415,7 @@ describe('QuestionCard', () => {
       ).toBeInTheDocument();
       expect(
         screen.getByRole('link', { name: /create free account/i })
-      ).toHaveAttribute('href', '/auth');
+      ).toHaveAttribute('href', '/auth?returnTo=/dashboard');
     });
 
     it('does not call addBookmark when guest clicks the bookmark icon', () => {

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Link as RouterLink } from "react-router-dom";
 import { Question } from "@/hooks/useQuestions";
 import { useBookmarks } from "@/hooks/useBookmarks";
 import { useAuth } from "@/hooks/useAuth";
@@ -247,12 +248,12 @@ export function QuestionCard({
                 <p className="text-sm text-popover-foreground mb-2">
                   Bookmarks need an account to persist — they'd disappear when you close the tab.
                 </p>
-                <a
-                  href="/auth"
+                <RouterLink
+                  to="/auth"
                   className="text-sm font-medium text-primary hover:underline"
                 >
                   Create free account
-                </a>
+                </RouterLink>
               </PopoverContent>
             </Popover>
           </div>

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -225,47 +225,36 @@ export function QuestionCard({
         {!user && (
           <div className="absolute top-4 right-4 flex items-center gap-1 opacity-40 hover:opacity-100 transition-opacity duration-200">
             <Calculator key={question.id} />
-            <div className="relative">
+            <Popover open={showGuestBookmarkPopover} onOpenChange={setShowGuestBookmarkPopover}>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-7 w-7"
-                    onClick={() => setShowGuestBookmarkPopover(true)}
-                    aria-label="Bookmark this question"
-                  >
-                    <Bookmark className="w-3.5 h-3.5" aria-hidden="true" />
-                  </Button>
+                  <PopoverTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7"
+                      aria-label="Bookmark this question"
+                    >
+                      <Bookmark className="w-3.5 h-3.5" aria-hidden="true" />
+                    </Button>
+                  </PopoverTrigger>
                 </TooltipTrigger>
                 <TooltipContent>
                   <p>Bookmark this question</p>
                 </TooltipContent>
               </Tooltip>
-              {showGuestBookmarkPopover && (
-                <div
-                  className="absolute z-10 right-0 top-full mt-1 w-64 bg-popover border border-border rounded-lg shadow-lg p-3"
-                  onClick={(e) => e.stopPropagation()}
+              <PopoverContent className="w-64 bg-popover border-border" align="end">
+                <p className="text-sm text-popover-foreground mb-2">
+                  Bookmarks need an account to persist — they'd disappear when you close the tab.
+                </p>
+                <a
+                  href="/auth"
+                  className="text-sm font-medium text-primary hover:underline"
                 >
-                  <button
-                    onClick={() => setShowGuestBookmarkPopover(false)}
-                    className="absolute top-2 right-2 text-muted-foreground hover:text-foreground text-xs"
-                    aria-label="Close"
-                  >
-                    ✕
-                  </button>
-                  <p className="text-sm text-popover-foreground mb-2 pr-4">
-                    Bookmarks need an account to persist — they'd disappear when you close the tab.
-                  </p>
-                  <a
-                    href="/auth"
-                    className="text-sm font-medium text-primary hover:underline"
-                  >
-                    Create free account
-                  </a>
-                </div>
-              )}
-            </div>
+                  Create free account
+                </a>
+              </PopoverContent>
+            </Popover>
           </div>
         )}
 

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -48,6 +48,7 @@ export function QuestionCard({
   const { userFeedback, submitFeedback, removeFeedback } = useExplanationFeedback(question.id);
   const [noteText, setNoteText] = useState('');
   const [isNoteOpen, setIsNoteOpen] = useState(false);
+  const [showGuestBookmarkPopover, setShowGuestBookmarkPopover] = useState(false);
 
   const bookmarked = isBookmarked(question.id);
   const existingNote = getBookmarkNote(question.id);
@@ -220,10 +221,51 @@ export function QuestionCard({
           </div>
         )}
 
-        {/* Calculator for non-logged-in users */}
+        {/* Floating actions for guests */}
         {!user && (
-          <div className="absolute top-4 right-4 opacity-40 hover:opacity-100 transition-opacity duration-200">
+          <div className="absolute top-4 right-4 flex items-center gap-1 opacity-40 hover:opacity-100 transition-opacity duration-200">
             <Calculator key={question.id} />
+            <div className="relative">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    onClick={() => setShowGuestBookmarkPopover(true)}
+                    aria-label="Bookmark this question"
+                  >
+                    <Bookmark className="w-3.5 h-3.5" aria-hidden="true" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Bookmark this question</p>
+                </TooltipContent>
+              </Tooltip>
+              {showGuestBookmarkPopover && (
+                <div
+                  className="absolute z-10 right-0 top-full mt-1 w-64 bg-popover border border-border rounded-lg shadow-lg p-3"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <button
+                    onClick={() => setShowGuestBookmarkPopover(false)}
+                    className="absolute top-2 right-2 text-muted-foreground hover:text-foreground text-xs"
+                    aria-label="Close"
+                  >
+                    ✕
+                  </button>
+                  <p className="text-sm text-popover-foreground mb-2 pr-4">
+                    Bookmarks need an account to persist — they'd disappear when you close the tab.
+                  </p>
+                  <a
+                    href="/auth"
+                    className="text-sm font-medium text-primary hover:underline"
+                  >
+                    Create free account
+                  </a>
+                </div>
+              )}
+            </div>
           </div>
         )}
 

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -249,7 +249,7 @@ export function QuestionCard({
                   Bookmarks need an account to persist — they'd disappear when you close the tab.
                 </p>
                 <RouterLink
-                  to="/auth"
+                  to="/auth?returnTo=/dashboard"
                   className="text-sm font-medium text-primary hover:underline"
                 >
                   Create free account

--- a/src/components/RandomPractice.test.tsx
+++ b/src/components/RandomPractice.test.tsx
@@ -88,6 +88,14 @@ vi.mock('@/hooks/useGlossaryTerms', () => ({
   useGlossaryTerms: () => ({ data: [] }),
 }));
 
+const mockToast = vi.fn();
+vi.mock('sonner', () => ({
+  toast: Object.assign((...args: unknown[]) => mockToast(...args), {
+    success: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
 vi.mock('framer-motion', () => ({
   motion: {
     div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement> & { children?: React.ReactNode }) => <div {...props}>{children}</div>,
@@ -345,6 +353,40 @@ describe('RandomPractice', () => {
         // Should be back to showing skip button (fresh question, not answered)
         expect(screen.getByRole('button', { name: /skip/i })).toBeInTheDocument();
       });
+    });
+  });
+
+  describe('Guest unmount toast', () => {
+    // The hook mock at the top of this file already returns { user: null }.
+
+    it('fires the save prompt toast when a guest unmounts after answering', async () => {
+      const { unmount } = renderRandomPractice();
+
+      // Answer one question so stats.total > 0
+      await waitFor(() => {
+        const optionA = screen
+          .getAllByRole('button')
+          .find((btn) => btn.textContent?.startsWith('A'));
+        expect(optionA).toBeDefined();
+      });
+      const optionA = screen
+        .getAllByRole('button')
+        .find((btn) => btn.textContent?.startsWith('A'));
+      fireEvent.click(optionA!);
+
+      unmount();
+
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.stringContaining("wasn't saved"),
+        expect.objectContaining({ duration: 5000 })
+      );
+    });
+
+    it('does not fire the toast on unmount if no questions were answered', () => {
+      const { unmount } = renderRandomPractice();
+      unmount();
+
+      expect(mockToast).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/RandomPractice.tsx
+++ b/src/components/RandomPractice.tsx
@@ -300,6 +300,15 @@ export function RandomPractice({
     setBestStreak(allTimeBestStreak);
   };
 
+  const handleBack = () => {
+    if (!user && stats.total > 0) {
+      toast("Your practice session wasn't saved — create a free account to track your progress.", {
+        duration: 5000,
+      });
+    }
+    onBack();
+  };
+
   const canGoBack = historyIndex > 0;
   const isViewingHistory = historyIndex < questionHistory.length - 1;
 
@@ -331,7 +340,7 @@ export function RandomPractice({
       <PageContainer width="standard" mobileNavPadding className="flex items-center justify-center">
         <div className="text-center">
           <p className="text-destructive mb-4">Failed to load questions</p>
-          <Button onClick={onBack}>Go Back</Button>
+          <Button onClick={handleBack}>Go Back</Button>
         </div>
       </PageContainer>
     );

--- a/src/components/RandomPractice.tsx
+++ b/src/components/RandomPractice.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { QuestionCard } from "@/components/QuestionCard";
 import { useQuestions, Question } from "@/hooks/useQuestions";
@@ -301,14 +301,25 @@ export function RandomPractice({
     setBestStreak(allTimeBestStreak);
   };
 
-  const handleBack = () => {
-    if (!user && stats.total > 0) {
-      toast("Your practice session wasn't saved — create a free account to track your progress.", {
-        duration: 5000,
-      });
-    }
-    onBack();
-  };
+  // Refs let the unmount cleanup read the latest user/stats without re-firing
+  // every time they change (an effect with [user, stats.total] deps would
+  // toast on each answered question).
+  const userRef = useRef(user);
+  const statsRef = useRef(stats);
+  useEffect(() => {
+    userRef.current = user;
+    statsRef.current = stats;
+  }, [user, stats]);
+
+  useEffect(() => {
+    return () => {
+      if (!userRef.current && statsRef.current.total > 0) {
+        toast("Your practice session wasn't saved — create a free account to track your progress.", {
+          duration: 5000,
+        });
+      }
+    };
+  }, []);
 
   const canGoBack = historyIndex > 0;
   const isViewingHistory = historyIndex < questionHistory.length - 1;
@@ -341,7 +352,7 @@ export function RandomPractice({
       <PageContainer width="standard" mobileNavPadding className="flex items-center justify-center">
         <div className="text-center">
           <p className="text-destructive mb-4">Failed to load questions</p>
-          <Button onClick={handleBack}>Go Back</Button>
+          <Button onClick={onBack}>Go Back</Button>
         </div>
       </PageContainer>
     );

--- a/src/components/RandomPractice.tsx
+++ b/src/components/RandomPractice.tsx
@@ -10,6 +10,7 @@ import { KeyboardShortcutsHelp } from "@/components/KeyboardShortcutsHelp";
 import { useQuestionTimer } from "@/hooks/useQuestionTimer";
 import { supabase } from "@/integrations/supabase/client";
 import { useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from '@/services/queryKeys';
 import { Zap, SkipForward, RotateCcw, Loader2, Flame, Trophy, Award, ChevronLeft } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { toast } from "sonner";
@@ -118,7 +119,7 @@ export function RandomPractice({
     }).eq('id', user.id);
 
     // Invalidate profile-stats query so dashboard updates
-    queryClient.invalidateQueries({ queryKey: ['profile-stats', user.id] });
+    queryClient.invalidateQueries({ queryKey: queryKeys.progress.profileStats(user.id) });
   };
   const getRandomQuestion = useCallback((excludeIds: string[] = []): { question: Question; shouldResetAskedIds: boolean } | null => {
     if (!allQuestions || allQuestions.length === 0) return null;

--- a/src/components/TestResults.test.tsx
+++ b/src/components/TestResults.test.tsx
@@ -14,6 +14,10 @@ vi.mock('framer-motion', () => ({
   },
 }));
 
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: null, loading: false }),
+}));
+
 vi.mock('@/hooks/useBookmarks', () => ({
   useBookmarks: () => ({
     isBookmarked: vi.fn(() => false),

--- a/src/components/TestResults.test.tsx
+++ b/src/components/TestResults.test.tsx
@@ -18,8 +18,14 @@ vi.mock('framer-motion', () => ({
   },
 }));
 
+// Default to an authenticated session so each test reflects realistic user state.
+// The Guest save card describe block overrides this to user: null.
+const mockUseAuth = vi.fn(() => ({
+  user: { id: 'test-user-id', email: 'test@example.com' },
+  loading: false,
+}));
 vi.mock('@/hooks/useAuth', () => ({
-  useAuth: () => ({ user: null, loading: false }),
+  useAuth: () => mockUseAuth(),
 }));
 
 vi.mock('@/hooks/useBookmarks', () => ({
@@ -472,6 +478,16 @@ describe('TestResults', () => {
   });
 
   describe('Guest save card', () => {
+    beforeEach(() => {
+      mockUseAuth.mockReturnValue({ user: null, loading: false });
+    });
+    afterEach(() => {
+      mockUseAuth.mockReturnValue({
+        user: { id: 'test-user-id', email: 'test@example.com' },
+        loading: false,
+      });
+    });
+
     it('shows save card for unauthenticated user', () => {
       const { questions, answers } = createQuestionsAndAnswers(35, 26, 'T');
 

--- a/src/components/TestResults.test.tsx
+++ b/src/components/TestResults.test.tsx
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { TestResults } from './TestResults';
 import { Question } from '@/hooks/useQuestions';
 import confetti from 'canvas-confetti';
+
+const renderWithRouter = (ui: React.ReactElement) =>
+  render(<MemoryRouter>{ui}</MemoryRouter>);
 
 vi.mock('canvas-confetti', () => ({
   default: vi.fn(),
@@ -80,7 +84,7 @@ describe('TestResults', () => {
     it('shows PASSED when score >= 26', () => {
       const { questions, answers } = createQuestionsAndAnswers(35, 26, 'T');
 
-      render(
+      renderWithRouter(
         <TestResults
           questions={questions}
           answers={answers}
@@ -96,7 +100,7 @@ describe('TestResults', () => {
     it('shows NOT PASSED when score < 26', () => {
       const { questions, answers } = createQuestionsAndAnswers(35, 25, 'T');
 
-      render(
+      renderWithRouter(
         <TestResults
           questions={questions}
           answers={answers}
@@ -112,7 +116,7 @@ describe('TestResults', () => {
     it('shows correct passing score text for technician', () => {
       const { questions, answers } = createQuestionsAndAnswers(35, 26, 'T');
 
-      render(
+      renderWithRouter(
         <TestResults
           questions={questions}
           answers={answers}
@@ -129,7 +133,7 @@ describe('TestResults', () => {
     it('shows PASSED when score >= 26', () => {
       const { questions, answers } = createQuestionsAndAnswers(35, 26, 'G');
 
-      render(
+      renderWithRouter(
         <TestResults
           questions={questions}
           answers={answers}
@@ -144,7 +148,7 @@ describe('TestResults', () => {
     it('shows NOT PASSED when score < 26', () => {
       const { questions, answers } = createQuestionsAndAnswers(35, 25, 'G');
 
-      render(
+      renderWithRouter(
         <TestResults
           questions={questions}
           answers={answers}
@@ -159,7 +163,7 @@ describe('TestResults', () => {
     it('shows correct passing score text for general', () => {
       const { questions, answers } = createQuestionsAndAnswers(35, 26, 'G');
 
-      render(
+      renderWithRouter(
         <TestResults
           questions={questions}
           answers={answers}
@@ -176,7 +180,7 @@ describe('TestResults', () => {
     it('shows PASSED when score >= 37', () => {
       const { questions, answers } = createQuestionsAndAnswers(50, 37, 'E');
 
-      render(
+      renderWithRouter(
         <TestResults
           questions={questions}
           answers={answers}
@@ -192,7 +196,7 @@ describe('TestResults', () => {
     it('shows NOT PASSED when score < 37', () => {
       const { questions, answers } = createQuestionsAndAnswers(50, 36, 'E');
 
-      render(
+      renderWithRouter(
         <TestResults
           questions={questions}
           answers={answers}
@@ -208,7 +212,7 @@ describe('TestResults', () => {
     it('shows correct passing score text for extra', () => {
       const { questions, answers } = createQuestionsAndAnswers(50, 37, 'E');
 
-      render(
+      renderWithRouter(
         <TestResults
           questions={questions}
           answers={answers}
@@ -223,7 +227,7 @@ describe('TestResults', () => {
     it('shows 26 correct as NOT PASSED for extra (would pass technician)', () => {
       const { questions, answers } = createQuestionsAndAnswers(50, 26, 'E');
 
-      render(
+      renderWithRouter(
         <TestResults
           questions={questions}
           answers={answers}
@@ -240,7 +244,7 @@ describe('TestResults', () => {
     it('displays correct, incorrect, and percentage', () => {
       const { questions, answers } = createQuestionsAndAnswers(35, 30, 'T');
 
-      render(
+      renderWithRouter(
         <TestResults
           questions={questions}
           answers={answers}
@@ -260,7 +264,7 @@ describe('TestResults', () => {
     it('displays score labels', () => {
       const { questions, answers } = createQuestionsAndAnswers(35, 26, 'T');
 
-      render(
+      renderWithRouter(
         <TestResults
           questions={questions}
           answers={answers}
@@ -280,7 +284,7 @@ describe('TestResults', () => {
       const onRetake = vi.fn();
       const { questions, answers } = createQuestionsAndAnswers(35, 26, 'T');
 
-      render(
+      renderWithRouter(
         <TestResults
           questions={questions}
           answers={answers}
@@ -298,7 +302,7 @@ describe('TestResults', () => {
       const onBack = vi.fn();
       const { questions, answers } = createQuestionsAndAnswers(35, 26, 'T');
 
-      render(
+      renderWithRouter(
         <TestResults
           questions={questions}
           answers={answers}
@@ -317,7 +321,7 @@ describe('TestResults', () => {
     it('displays all questions in review list', () => {
       const { questions, answers } = createQuestionsAndAnswers(5, 3, 'T');
 
-      render(
+      renderWithRouter(
         <TestResults
           questions={questions}
           answers={answers}
@@ -338,7 +342,7 @@ describe('TestResults', () => {
     it('defaults to technician config when testType is not provided', () => {
       const { questions, answers } = createQuestionsAndAnswers(35, 26, 'T');
 
-      render(
+      renderWithRouter(
         <TestResults
           questions={questions}
           answers={answers}
@@ -364,7 +368,7 @@ describe('TestResults', () => {
     it('fires confetti when user passes (after delay)', () => {
       const { questions, answers } = createQuestionsAndAnswers(35, 26, 'T');
 
-      render(
+      renderWithRouter(
         <TestResults
           questions={questions}
           answers={answers}
@@ -389,7 +393,7 @@ describe('TestResults', () => {
     it('does not fire confetti when user fails', () => {
       const { questions, answers } = createQuestionsAndAnswers(35, 25, 'T');
 
-      render(
+      renderWithRouter(
         <TestResults
           questions={questions}
           answers={answers}
@@ -407,24 +411,28 @@ describe('TestResults', () => {
       const { questions, answers } = createQuestionsAndAnswers(35, 26, 'T');
 
       const { rerender } = render(
-        <TestResults
-          questions={questions}
-          answers={answers}
-          testType="technician"
-          {...defaultProps}
-        />
+        <MemoryRouter>
+          <TestResults
+            questions={questions}
+            answers={answers}
+            testType="technician"
+            {...defaultProps}
+          />
+        </MemoryRouter>
       );
 
       vi.advanceTimersByTime(200);
 
       // Re-render with same props
       rerender(
-        <TestResults
-          questions={questions}
-          answers={answers}
-          testType="technician"
-          {...defaultProps}
-        />
+        <MemoryRouter>
+          <TestResults
+            questions={questions}
+            answers={answers}
+            testType="technician"
+            {...defaultProps}
+          />
+        </MemoryRouter>
       );
 
       vi.advanceTimersByTime(200);
@@ -448,7 +456,7 @@ describe('TestResults', () => {
       }));
       window.matchMedia = matchMediaMock;
 
-      render(
+      renderWithRouter(
         <TestResults
           questions={questions}
           answers={answers}
@@ -460,6 +468,48 @@ describe('TestResults', () => {
       vi.advanceTimersByTime(200);
 
       expect(confetti).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Guest save card', () => {
+    it('shows save card for unauthenticated user', () => {
+      const { questions, answers } = createQuestionsAndAnswers(35, 26, 'T');
+
+      renderWithRouter(
+        <TestResults
+          questions={questions}
+          answers={answers}
+          testType="technician"
+          {...defaultProps}
+        />
+      );
+
+      expect(
+        screen.getByText(/test results require an account to save/i)
+      ).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /create free account/i })).toHaveAttribute(
+        'href',
+        '/auth?returnTo=/dashboard'
+      );
+    });
+
+    it('dismisses save card when "Continue without saving" is clicked', () => {
+      const { questions, answers } = createQuestionsAndAnswers(35, 26, 'T');
+
+      renderWithRouter(
+        <TestResults
+          questions={questions}
+          answers={answers}
+          testType="technician"
+          {...defaultProps}
+        />
+      );
+
+      fireEvent.click(screen.getByText(/continue without saving/i));
+
+      expect(
+        screen.queryByText(/test results require an account to save/i)
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/TestResults.tsx
+++ b/src/components/TestResults.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import { useAuth } from "@/hooks/useAuth";
 import confetti from "canvas-confetti";
 import { Button } from "@/components/ui/button";
 import { Question } from "@/hooks/useQuestions";
@@ -18,7 +19,9 @@ interface TestResultsProps {
 }
 
 export function TestResults({ questions, answers, onRetake, onBack, testType = 'technician' }: TestResultsProps) {
+  const { user } = useAuth();
   const [reviewIndex, setReviewIndex] = useState<number | null>(null);
+  const [saveCardDismissed, setSaveCardDismissed] = useState(false);
 
   const { questionCount, passingScore } = testConfig[testType];
   const correctCount = questions.filter(
@@ -168,6 +171,28 @@ export function TestResults({ questions, answers, onRetake, onBack, testType = '
             Passing score: {passingScore} out of {questionCount} (74%)
           </p>
         </motion.div>
+
+        {!user && !saveCardDismissed && (
+          <div className="border border-border rounded-lg p-4 mb-6 bg-card">
+            <p className="text-sm text-muted-foreground mb-3">
+              Test results require an account to save — there's nowhere to put them without one.
+            </p>
+            <div className="flex items-center gap-3">
+              <a
+                href="/auth?returnTo=/dashboard"
+                className="text-sm font-medium text-primary hover:underline"
+              >
+                Create free account
+              </a>
+              <button
+                onClick={() => setSaveCardDismissed(true)}
+                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+              >
+                Continue without saving
+              </button>
+            </div>
+          </div>
+        )}
 
         {/* Action Buttons */}
         <motion.div

--- a/src/components/TestResults.tsx
+++ b/src/components/TestResults.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import { Link } from "react-router-dom";
 import { useAuth } from "@/hooks/useAuth";
 import confetti from "canvas-confetti";
 import { Button } from "@/components/ui/button";
@@ -178,12 +179,12 @@ export function TestResults({ questions, answers, onRetake, onBack, testType = '
               Test results require an account to save — there's nowhere to put them without one.
             </p>
             <div className="flex items-center gap-3">
-              <a
-                href="/auth?returnTo=/dashboard"
+              <Link
+                to="/auth?returnTo=/dashboard"
                 className="text-sm font-medium text-primary hover:underline"
               >
                 Create free account
-              </a>
+              </Link>
               <button
                 onClick={() => setSaveCardDismissed(true)}
                 className="text-sm text-muted-foreground hover:text-foreground transition-colors"

--- a/src/components/sidebar/SidebarFooter.test.tsx
+++ b/src/components/sidebar/SidebarFooter.test.tsx
@@ -140,4 +140,22 @@ describe('SidebarFooter', () => {
       expect(screen.getByText('Admin')).toBeInTheDocument();
     });
   });
+
+  describe('Guest State', () => {
+    it('shows Sign in link when userInfo is undefined', () => {
+      renderWithTooltip(<SidebarFooter {...defaultProps} userInfo={undefined} />);
+      expect(screen.getByRole('link', { name: /sign in/i })).toHaveAttribute('href', '/auth');
+    });
+
+    it('shows user profile button when userInfo is provided', () => {
+      renderWithTooltip(
+        <SidebarFooter
+          {...defaultProps}
+          userInfo={{ displayName: 'Ada Lovelace', email: 'ada@example.com', forumUsername: null }}
+        />
+      );
+      expect(screen.getByText('Ada Lovelace')).toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: /sign in/i })).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/sidebar/SidebarFooter.test.tsx
+++ b/src/components/sidebar/SidebarFooter.test.tsx
@@ -149,7 +149,10 @@ describe('SidebarFooter', () => {
   describe('Guest State', () => {
     it('shows Sign in link when userInfo is undefined', () => {
       renderWithTooltip(<SidebarFooter {...defaultProps} userInfo={undefined} />);
-      expect(screen.getByRole('link', { name: /sign in/i })).toHaveAttribute('href', '/auth');
+      expect(screen.getByRole('link', { name: /sign in/i })).toHaveAttribute(
+        'href',
+        '/auth?returnTo=/dashboard'
+      );
     });
 
     it('shows user profile button when userInfo is provided', () => {

--- a/src/components/sidebar/SidebarFooter.test.tsx
+++ b/src/components/sidebar/SidebarFooter.test.tsx
@@ -157,5 +157,20 @@ describe('SidebarFooter', () => {
       expect(screen.getByText('Ada Lovelace')).toBeInTheDocument();
       expect(screen.queryByRole('link', { name: /sign in/i })).not.toBeInTheDocument();
     });
+
+    it('shows icon-only sign in when sidebar is collapsed', () => {
+      const baseProps = { ...defaultProps, isAdmin: false, onAdminClick: vi.fn() };
+      renderWithTooltip(
+        <SidebarFooter
+          {...baseProps}
+          isCollapsed={true}
+          isMobile={false}
+          userInfo={undefined}
+        />
+      );
+      expect(screen.getByRole('link', { name: /sign in/i })).toBeInTheDocument();
+      // Full text label should not be visible in collapsed state
+      expect(screen.queryByText('Sign in →')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/sidebar/SidebarFooter.test.tsx
+++ b/src/components/sidebar/SidebarFooter.test.tsx
@@ -1,11 +1,16 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
 import { SidebarFooter } from './SidebarFooter';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
 const renderWithTooltip = (component: React.ReactNode) => {
-  return render(<TooltipProvider>{component}</TooltipProvider>);
+  return render(
+    <MemoryRouter>
+      <TooltipProvider>{component}</TooltipProvider>
+    </MemoryRouter>
+  );
 };
 
 describe('SidebarFooter', () => {

--- a/src/components/sidebar/SidebarFooter.tsx
+++ b/src/components/sidebar/SidebarFooter.tsx
@@ -1,4 +1,5 @@
 import { Shield, LogIn } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -96,13 +97,13 @@ export function SidebarFooter({
           <div className="p-2 flex justify-center">
             <Tooltip delayDuration={0}>
               <TooltipTrigger asChild>
-                <a
-                  href="/auth"
+                <Link
+                  to="/auth"
                   className="flex items-center justify-center w-10 h-10 rounded-lg text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
                   aria-label="Sign in"
                 >
                   <LogIn className="w-5 h-5" />
-                </a>
+                </Link>
               </TooltipTrigger>
               <TooltipContent side="right" className="bg-popover border-border">
                 <p>Sign in</p>
@@ -111,12 +112,12 @@ export function SidebarFooter({
           </div>
         ) : (
           <div className="p-3">
-            <a
-              href="/auth"
+            <Link
+              to="/auth"
               className="text-sm font-medium text-primary hover:underline"
             >
               Sign in →
-            </a>
+            </Link>
           </div>
         )
       )}

--- a/src/components/sidebar/SidebarFooter.tsx
+++ b/src/components/sidebar/SidebarFooter.tsx
@@ -1,4 +1,4 @@
-import { Shield } from 'lucide-react';
+import { Shield, LogIn } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -92,14 +92,33 @@ export function SidebarFooter({
 
       {/* Guest: Sign in link */}
       {!userInfo && (
-        <div className="p-3">
-          <a
-            href="/auth"
-            className="text-sm font-medium text-primary hover:underline"
-          >
-            Sign in →
-          </a>
-        </div>
+        !showExpanded ? (
+          <div className="p-2 flex justify-center">
+            <Tooltip delayDuration={0}>
+              <TooltipTrigger asChild>
+                <a
+                  href="/auth"
+                  className="flex items-center justify-center w-10 h-10 rounded-lg text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+                  aria-label="Sign in"
+                >
+                  <LogIn className="w-5 h-5" />
+                </a>
+              </TooltipTrigger>
+              <TooltipContent side="right" className="bg-popover border-border">
+                <p>Sign in</p>
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        ) : (
+          <div className="p-3">
+            <a
+              href="/auth"
+              className="text-sm font-medium text-primary hover:underline"
+            >
+              Sign in →
+            </a>
+          </div>
+        )
       )}
 
       {/* Authenticated: User Profile Section */}

--- a/src/components/sidebar/SidebarFooter.tsx
+++ b/src/components/sidebar/SidebarFooter.tsx
@@ -98,7 +98,7 @@ export function SidebarFooter({
             <Tooltip delayDuration={0}>
               <TooltipTrigger asChild>
                 <Link
-                  to="/auth"
+                  to="/auth?returnTo=/dashboard"
                   className="flex items-center justify-center w-10 h-10 rounded-lg text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
                   aria-label="Sign in"
                 >
@@ -113,7 +113,7 @@ export function SidebarFooter({
         ) : (
           <div className="p-3">
             <Link
-              to="/auth"
+              to="/auth?returnTo=/dashboard"
               className="text-sm font-medium text-primary hover:underline"
             >
               Sign in →

--- a/src/components/sidebar/SidebarFooter.tsx
+++ b/src/components/sidebar/SidebarFooter.tsx
@@ -90,53 +90,67 @@ export function SidebarFooter({
         </div>
       )}
 
-      {/* User Profile Section */}
-      <div
-        className={cn(
-          'p-3',
-          !isMobile && isCollapsed && 'flex justify-center'
-        )}
-      >
-        {showExpanded ? (
-          <button
-            onClick={onProfileClick}
-            className="w-full flex items-center gap-3 p-2 -m-2 rounded-lg hover:bg-secondary transition-colors"
+      {/* Guest: Sign in link */}
+      {!userInfo && (
+        <div className="p-3">
+          <a
+            href="/auth"
+            className="text-sm font-medium text-primary hover:underline"
           >
-            <Avatar className="h-9 w-9 shrink-0">
-              <AvatarFallback className="bg-primary/10 text-primary text-sm font-medium">
-                {getInitials()}
-              </AvatarFallback>
-            </Avatar>
-            <div className="flex-1 min-w-0 text-left">
-              <p className="text-sm font-medium text-foreground truncate">
-                {userInfo?.displayName || 'User'}
-              </p>
-              <p className="text-sm text-muted-foreground truncate">
-                {userInfo?.email || ''}
-              </p>
-            </div>
-          </button>
-        ) : (
-          <Tooltip delayDuration={0}>
-            <TooltipTrigger asChild>
-              <button
-                onClick={onProfileClick}
-                className="rounded-full hover:ring-2 hover:ring-primary/20 transition-all"
-              >
-                <Avatar className="h-8 w-8 cursor-pointer">
-                  <AvatarFallback className="bg-primary/10 text-primary text-xs font-medium">
-                    {getInitials()}
-                  </AvatarFallback>
-                </Avatar>
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="right" className="bg-popover border-border">
-              <p className="font-medium">{userInfo?.displayName || 'User'}</p>
-              <p className="text-xs text-muted-foreground">{userInfo?.email}</p>
-            </TooltipContent>
-          </Tooltip>
-        )}
-      </div>
+            Sign in →
+          </a>
+        </div>
+      )}
+
+      {/* Authenticated: User Profile Section */}
+      {userInfo && (
+        <div
+          className={cn(
+            'p-3',
+            !isMobile && isCollapsed && 'flex justify-center'
+          )}
+        >
+          {showExpanded ? (
+            <button
+              onClick={onProfileClick}
+              className="w-full flex items-center gap-3 p-2 -m-2 rounded-lg hover:bg-secondary transition-colors"
+            >
+              <Avatar className="h-9 w-9 shrink-0">
+                <AvatarFallback className="bg-primary/10 text-primary text-sm font-medium">
+                  {getInitials()}
+                </AvatarFallback>
+              </Avatar>
+              <div className="flex-1 min-w-0 text-left">
+                <p className="text-sm font-medium text-foreground truncate">
+                  {userInfo.displayName || 'User'}
+                </p>
+                <p className="text-sm text-muted-foreground truncate">
+                  {userInfo.email || ''}
+                </p>
+              </div>
+            </button>
+          ) : (
+            <Tooltip delayDuration={0}>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={onProfileClick}
+                  className="rounded-full hover:ring-2 hover:ring-primary/20 transition-all"
+                >
+                  <Avatar className="h-8 w-8 cursor-pointer">
+                    <AvatarFallback className="bg-primary/10 text-primary text-xs font-medium">
+                      {getInitials()}
+                    </AvatarFallback>
+                  </Avatar>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="right" className="bg-popover border-border">
+                <p className="font-medium">{userInfo.displayName || 'User'}</p>
+                <p className="text-xs text-muted-foreground">{userInfo.email}</p>
+              </TooltipContent>
+            </Tooltip>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -556,6 +556,28 @@ export default function Auth() {
             Continue with Google
           </Button>
 
+          {/* Guest entry divider */}
+          <div className="relative my-4">
+            <div className="absolute inset-0 flex items-center">
+              <span className="w-full border-t border-border" />
+            </div>
+            <div className="relative flex justify-center text-xs">
+              <span className="bg-card px-2 text-muted-foreground">or</span>
+            </div>
+          </div>
+
+          {/* Continue as guest */}
+          <div
+            className="border border-dashed border-border rounded-md px-4 py-3 cursor-pointer hover:bg-accent/50 transition-colors"
+            onClick={() => navigate('/dashboard')}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') navigate('/dashboard'); }}
+          >
+            <p className="text-foreground text-sm font-medium">Continue as guest →</p>
+            <p className="text-muted-foreground text-sm">Progress won't be saved</p>
+          </div>
+
           <div className="mt-6 text-center">
             <button
               type="button"

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -567,16 +567,14 @@ export default function Auth() {
           </div>
 
           {/* Continue as guest */}
-          <div
-            className="border border-dashed border-border rounded-md px-4 py-3 cursor-pointer hover:bg-accent/50 transition-colors"
+          <button
+            type="button"
             onClick={() => navigate('/dashboard')}
-            role="button"
-            tabIndex={0}
-            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') navigate('/dashboard'); }}
+            className="w-full text-left border border-dashed border-border rounded-md px-4 py-3 cursor-pointer hover:bg-accent/50 transition-colors"
           >
             <p className="text-foreground text-sm font-medium">Continue as guest →</p>
             <p className="text-muted-foreground text-sm">Progress won't be saved</p>
-          </div>
+          </button>
 
           <div className="mt-6 text-center">
             <button

--- a/src/pages/Dashboard.test.tsx
+++ b/src/pages/Dashboard.test.tsx
@@ -202,9 +202,8 @@ describe('Dashboard', () => {
     });
   });
 
-  describe('Authentication Redirect', () => {
-    it('redirects to auth page when user is not authenticated', async () => {
-      // Override useAuth mock for this test
+  describe('Guest mode', () => {
+    it('shows guest dashboard (not redirect) when user is not authenticated', async () => {
       mockAuthHook.mockReturnValueOnce({
         user: null,
         loading: false,
@@ -213,8 +212,9 @@ describe('Dashboard', () => {
       renderDashboard();
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/auth');
+        expect(screen.getByText('Start Studying')).toBeInTheDocument();
       });
+      expect(mockNavigate).not.toHaveBeenCalledWith('/auth');
     });
   });
 });

--- a/src/pages/Dashboard.test.tsx
+++ b/src/pages/Dashboard.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { TooltipProvider } from '@/components/ui/tooltip';
@@ -154,6 +154,16 @@ vi.mock('@/components/WeeklyGoalsModal', () => ({
   WeeklyGoalsModal: () => null,
 }));
 
+// Mock dashboard subcomponents that have their own data dependencies
+vi.mock('@/components/dashboard', () => ({
+  DashboardHero: () => <div data-testid="dashboard-hero" />,
+  DashboardNextSteps: () => <div data-testid="dashboard-next-steps" />,
+  DashboardNotifications: () => <div data-testid="dashboard-notifications" />,
+  DashboardProgress: () => <div data-testid="dashboard-progress" />,
+  DashboardSectionInsights: () => <div data-testid="dashboard-section-insights" />,
+  StreakDisplay: () => <div data-testid="streak-display" />,
+}));
+
 const createTestQueryClient = () =>
   new QueryClient({
     defaultOptions: {
@@ -203,18 +213,51 @@ describe('Dashboard', () => {
   });
 
   describe('Guest mode', () => {
-    it('renders main dashboard (not a redirect) when user is not authenticated', async () => {
-      mockAuthHook.mockReturnValueOnce({
-        user: null,
-        loading: false,
-      });
+    const asGuest = () => {
+      // Set up the guest mock for every useAuth call this render makes,
+      // then reset back to the authed default after the test.
+      mockAuthHook.mockReturnValue({ user: null, loading: false });
+    };
 
+    beforeEach(() => {
+      localStorage.removeItem('guest_banner_dismissed');
+    });
+
+    afterEach(() => {
+      mockAuthHook.mockReturnValue({ user: mockUser, loading: false });
+    });
+
+    it('renders main dashboard (not a redirect) when user is not authenticated', async () => {
+      asGuest();
       renderDashboard();
 
       await waitFor(() => {
         expect(screen.getByText(/you're studying as a guest/i)).toBeInTheDocument();
       });
       expect(mockNavigate).not.toHaveBeenCalledWith('/auth');
+    });
+
+    it('persists banner dismissal to localStorage', async () => {
+      asGuest();
+      renderDashboard();
+
+      const dismissBtn = await screen.findByRole('button', { name: /dismiss banner/i });
+      fireEvent.click(dismissBtn);
+
+      expect(localStorage.getItem('guest_banner_dismissed')).toBe('true');
+      expect(screen.queryByText(/you're studying as a guest/i)).not.toBeInTheDocument();
+    });
+
+    it('hides banner on subsequent mounts when localStorage flag is set', async () => {
+      asGuest();
+      localStorage.setItem('guest_banner_dismissed', 'true');
+
+      renderDashboard();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('app-layout')).toBeInTheDocument();
+      });
+      expect(screen.queryByText(/you're studying as a guest/i)).not.toBeInTheDocument();
     });
   });
 });

--- a/src/pages/Dashboard.test.tsx
+++ b/src/pages/Dashboard.test.tsx
@@ -203,7 +203,7 @@ describe('Dashboard', () => {
   });
 
   describe('Guest mode', () => {
-    it('shows guest dashboard (not redirect) when user is not authenticated', async () => {
+    it('renders main dashboard (not a redirect) when user is not authenticated', async () => {
       mockAuthHook.mockReturnValueOnce({
         user: null,
         loading: false,
@@ -212,7 +212,7 @@ describe('Dashboard', () => {
       renderDashboard();
 
       await waitFor(() => {
-        expect(screen.getByText('Start Studying')).toBeInTheDocument();
+        expect(screen.getByText(/you're studying as a guest/i)).toBeInTheDocument();
       });
       expect(mockNavigate).not.toHaveBeenCalledWith('/auth');
     });

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { useAuth } from '@/hooks/useAuth';
 import { useBookmarks } from '@/hooks/useBookmarks';
@@ -12,7 +12,7 @@ import { queryKeys } from '@/services/queryKeys';
 import { calculateWeakQuestionIds } from '@/lib/weakQuestions';
 import { filterByTestType } from '@/lib/testTypeUtils';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
-import { Loader2, AlertTriangle, Zap, Brain, Target, MapPin } from 'lucide-react';
+import { Loader2, AlertTriangle, Zap, Brain, Target, MapPin, X } from 'lucide-react';
 import { GlobalSearch } from '@/components/GlobalSearch';
 import { PageContainer } from '@/components/ui/page-container';
 import {
@@ -391,9 +391,9 @@ export default function Dashboard() {
           <div className="flex items-center justify-between gap-3 bg-primary/10 border border-primary/20 rounded-lg px-4 py-3 mb-6">
             <p className="text-sm text-foreground">
               You're studying as a guest — progress isn't being saved.{' '}
-              <a href="/auth?returnTo=/dashboard" className="text-primary hover:underline font-medium">
+              <Link to="/auth?returnTo=/dashboard" className="text-primary hover:underline font-medium">
                 Create a free account
-              </a>
+              </Link>
             </p>
             <button
               onClick={() => {
@@ -403,7 +403,7 @@ export default function Dashboard() {
               aria-label="Dismiss banner"
               className="text-muted-foreground hover:text-foreground transition-colors flex-shrink-0"
             >
-              ✕
+              <X className="w-4 h-4" />
             </button>
           </div>
         )}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -391,7 +391,7 @@ export default function Dashboard() {
           <div className="flex items-center justify-between gap-3 bg-primary/10 border border-primary/20 rounded-lg px-4 py-3 mb-6">
             <p className="text-sm text-foreground">
               You're studying as a guest — progress isn't being saved.{' '}
-              <a href="/auth" className="text-primary hover:underline font-medium">
+              <a href="/auth?returnTo=/dashboard" className="text-primary hover:underline font-medium">
                 Create a free account
               </a>
             </p>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -12,7 +12,7 @@ import { queryKeys } from '@/services/queryKeys';
 import { calculateWeakQuestionIds } from '@/lib/weakQuestions';
 import { filterByTestType } from '@/lib/testTypeUtils';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
-import { Loader2, AlertTriangle, Zap, Brain, Target, MapPin, BookOpen, Shuffle, GraduationCap, BookMarked } from 'lucide-react';
+import { Loader2, AlertTriangle, Zap, Brain, Target, MapPin } from 'lucide-react';
 import { GlobalSearch } from '@/components/GlobalSearch';
 import { PageContainer } from '@/components/ui/page-container';
 import {
@@ -305,111 +305,6 @@ export default function Dashboard() {
           <Loader2 className="w-8 h-8 animate-spin text-primary" />
         </div>;
     }
-    if (!user) {
-      return (
-        <PageContainer width="standard" radioWaveBg>
-          {!guestBannerDismissed && (
-            <div className="flex items-center justify-between gap-3 bg-primary/10 border border-primary/20 rounded-lg px-4 py-3 mb-6">
-              <p className="text-sm text-foreground">
-                You're studying as a guest — progress isn't being saved.{' '}
-                <a href="/auth" className="text-primary hover:underline font-medium">
-                  Create a free account
-                </a>
-              </p>
-              <button
-                onClick={() => {
-                  localStorage.setItem('guest_banner_dismissed', 'true');
-                  setGuestBannerDismissed(true);
-                }}
-                aria-label="Dismiss banner"
-                className="text-muted-foreground hover:text-foreground transition-colors flex-shrink-0"
-              >
-                ✕
-              </button>
-            </div>
-          )}
-
-          <div className="mb-6">
-            <h2 className="text-lg font-semibold text-foreground mb-1">Start Studying</h2>
-            <p className="text-sm text-muted-foreground">Pick a study mode to get started.</p>
-          </div>
-
-          <div className="grid grid-cols-2 sm:grid-cols-2 gap-4 mb-8">
-            <button
-              onClick={() => changeView('practice-test')}
-              className="bg-card border border-border rounded-lg p-4 cursor-pointer hover:bg-accent/50 transition-colors text-left"
-            >
-              <GraduationCap className="w-6 h-6 text-primary mb-2" />
-              <span className="text-sm font-medium text-foreground">Practice Test</span>
-            </button>
-            <button
-              onClick={() => changeView('random-practice')}
-              className="bg-card border border-border rounded-lg p-4 cursor-pointer hover:bg-accent/50 transition-colors text-left"
-            >
-              <Shuffle className="w-6 h-6 text-primary mb-2" />
-              <span className="text-sm font-medium text-foreground">Random Practice</span>
-            </button>
-            <button
-              onClick={() => changeView('topics')}
-              className="bg-card border border-border rounded-lg p-4 cursor-pointer hover:bg-accent/50 transition-colors text-left"
-            >
-              <BookOpen className="w-6 h-6 text-primary mb-2" />
-              <span className="text-sm font-medium text-foreground">Study by Topic</span>
-            </button>
-            <button
-              onClick={() => changeView('glossary')}
-              className="bg-card border border-border rounded-lg p-4 cursor-pointer hover:bg-accent/50 transition-colors text-left"
-            >
-              <BookMarked className="w-6 h-6 text-primary mb-2" />
-              <span className="text-sm font-medium text-foreground">Glossary</span>
-            </button>
-          </div>
-
-          <div className="space-y-3">
-            <div className="bg-muted/50 border border-border rounded-lg p-4">
-              <p className="text-sm font-medium text-muted-foreground mb-1">Readiness Score</p>
-              <p className="text-sm text-muted-foreground mb-2">
-                Tracking your readiness over time requires an account — there's nowhere to save it without one.
-              </p>
-              <a href="/auth" className="text-sm text-primary hover:underline">Create a free account</a>
-            </div>
-
-            <div className="bg-muted/50 border border-border rounded-lg p-4">
-              <p className="text-sm font-medium text-muted-foreground mb-1">Streak</p>
-              <p className="text-sm text-muted-foreground mb-2">
-                Tracking your streak requires an account to record each session.
-              </p>
-              <a href="/auth" className="text-sm text-primary hover:underline">Create a free account</a>
-            </div>
-
-            <div className="bg-muted/50 border border-border rounded-lg p-4">
-              <p className="text-sm font-medium text-muted-foreground mb-1">Weak Questions</p>
-              <p className="text-sm text-muted-foreground mb-2">
-                Identifying weak areas requires a history of your answers, which needs an account.
-              </p>
-              <a href="/auth" className="text-sm text-primary hover:underline">Create a free account</a>
-            </div>
-
-            <div className="bg-muted/50 border border-border rounded-lg p-4">
-              <p className="text-sm font-medium text-muted-foreground mb-1">Recent Tests</p>
-              <p className="text-sm text-muted-foreground mb-2">
-                Tracking your progress over time requires an account — there's nowhere to save it without one.
-              </p>
-              <a href="/auth" className="text-sm text-primary hover:underline">Create a free account</a>
-            </div>
-
-            <div className="bg-muted/50 border border-border rounded-lg p-4">
-              <p className="text-sm font-medium text-muted-foreground mb-1">Bookmarks</p>
-              <p className="text-sm text-muted-foreground mb-2">
-                Bookmarks need an account to persist — otherwise they disappear when you close the tab.
-              </p>
-              <a href="/auth" className="text-sm text-primary hover:underline">Create a free account</a>
-            </div>
-          </div>
-        </PageContainer>
-      );
-    }
-
     // Calculate weekly goal progress
     const questionsGoal = weeklyGoals?.questions_goal || 50;
     const testsGoal = weeklyGoals?.tests_goal || 2;
@@ -491,6 +386,28 @@ export default function Dashboard() {
 
     return (
       <PageContainer width="standard" radioWaveBg>
+        {/* Guest banner — shown to unauthenticated users, dismissible */}
+        {!user && !guestBannerDismissed && (
+          <div className="flex items-center justify-between gap-3 bg-primary/10 border border-primary/20 rounded-lg px-4 py-3 mb-6">
+            <p className="text-sm text-foreground">
+              You're studying as a guest — progress isn't being saved.{' '}
+              <a href="/auth" className="text-primary hover:underline font-medium">
+                Create a free account
+              </a>
+            </p>
+            <button
+              onClick={() => {
+                localStorage.setItem('guest_banner_dismissed', 'true');
+                setGuestBannerDismissed(true);
+              }}
+              aria-label="Dismiss banner"
+              className="text-muted-foreground hover:text-foreground transition-colors flex-shrink-0"
+            >
+              ✕
+            </button>
+          </div>
+        )}
+
         <DashboardHero
           readinessLevel={readinessLevel}
           readinessTitle={readinessTitle}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -12,7 +12,7 @@ import { queryKeys } from '@/services/queryKeys';
 import { calculateWeakQuestionIds } from '@/lib/weakQuestions';
 import { filterByTestType } from '@/lib/testTypeUtils';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
-import { Loader2, AlertTriangle, Zap, Brain, Target, MapPin } from 'lucide-react';
+import { Loader2, AlertTriangle, Zap, Brain, Target, MapPin, BookOpen, Shuffle, GraduationCap, BookMarked } from 'lucide-react';
 import { GlobalSearch } from '@/components/GlobalSearch';
 import { PageContainer } from '@/components/ui/page-container';
 import {
@@ -82,6 +82,10 @@ export default function Dashboard() {
   const [showGoalsModal, setShowGoalsModal] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
 
+  const [guestBannerDismissed, setGuestBannerDismissed] = useState(
+    () => localStorage.getItem('guest_banner_dismissed') === 'true'
+  );
+
   // Global keyboard shortcut for search (Cmd/Ctrl+K)
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -127,11 +131,6 @@ export default function Dashboard() {
       trackLicenseTypeChanged({ new_type: newType, previous_type: previousType });
     }
   };
-  useEffect(() => {
-    if (!authLoading && !user) {
-      navigate('/auth');
-    }
-  }, [user, authLoading, navigate]);
   const {
     data: testResults,
     isLoading: testsLoading
@@ -301,12 +300,115 @@ export default function Dashboard() {
     if (currentView === 'lesson-detail' && selectedLessonSlug) {
       return <LessonDetailPage slug={selectedLessonSlug} onBack={navigateToLessons} />;
     }
-    if (authLoading || testsLoading || attemptsLoading) {
+    if (authLoading || (user && (testsLoading || attemptsLoading))) {
       return <div className="min-h-screen bg-background flex items-center justify-center">
           <Loader2 className="w-8 h-8 animate-spin text-primary" />
         </div>;
     }
-    if (!user) return null;
+    if (!user) {
+      return (
+        <PageContainer width="standard" radioWaveBg>
+          {!guestBannerDismissed && (
+            <div className="flex items-center justify-between gap-3 bg-primary/10 border border-primary/20 rounded-lg px-4 py-3 mb-6">
+              <p className="text-sm text-foreground">
+                You're studying as a guest — progress isn't being saved.{' '}
+                <a href="/auth" className="text-primary hover:underline font-medium">
+                  Create a free account
+                </a>
+              </p>
+              <button
+                onClick={() => {
+                  localStorage.setItem('guest_banner_dismissed', 'true');
+                  setGuestBannerDismissed(true);
+                }}
+                aria-label="Dismiss banner"
+                className="text-muted-foreground hover:text-foreground transition-colors flex-shrink-0"
+              >
+                ✕
+              </button>
+            </div>
+          )}
+
+          <div className="mb-6">
+            <h2 className="text-lg font-semibold text-foreground mb-1">Start Studying</h2>
+            <p className="text-sm text-muted-foreground">Pick a study mode to get started.</p>
+          </div>
+
+          <div className="grid grid-cols-2 sm:grid-cols-2 gap-4 mb-8">
+            <button
+              onClick={() => changeView('practice-test')}
+              className="bg-card border border-border rounded-lg p-4 cursor-pointer hover:bg-accent/50 transition-colors text-left"
+            >
+              <GraduationCap className="w-6 h-6 text-primary mb-2" />
+              <span className="text-sm font-medium text-foreground">Practice Test</span>
+            </button>
+            <button
+              onClick={() => changeView('random-practice')}
+              className="bg-card border border-border rounded-lg p-4 cursor-pointer hover:bg-accent/50 transition-colors text-left"
+            >
+              <Shuffle className="w-6 h-6 text-primary mb-2" />
+              <span className="text-sm font-medium text-foreground">Random Practice</span>
+            </button>
+            <button
+              onClick={() => changeView('topics')}
+              className="bg-card border border-border rounded-lg p-4 cursor-pointer hover:bg-accent/50 transition-colors text-left"
+            >
+              <BookOpen className="w-6 h-6 text-primary mb-2" />
+              <span className="text-sm font-medium text-foreground">Study by Topic</span>
+            </button>
+            <button
+              onClick={() => changeView('glossary')}
+              className="bg-card border border-border rounded-lg p-4 cursor-pointer hover:bg-accent/50 transition-colors text-left"
+            >
+              <BookMarked className="w-6 h-6 text-primary mb-2" />
+              <span className="text-sm font-medium text-foreground">Glossary</span>
+            </button>
+          </div>
+
+          <div className="space-y-3">
+            <div className="bg-muted/50 border border-border rounded-lg p-4">
+              <p className="text-sm font-medium text-muted-foreground mb-1">Readiness Score</p>
+              <p className="text-sm text-muted-foreground mb-2">
+                Tracking your readiness over time requires an account — there's nowhere to save it without one.
+              </p>
+              <a href="/auth" className="text-sm text-primary hover:underline">Create a free account</a>
+            </div>
+
+            <div className="bg-muted/50 border border-border rounded-lg p-4">
+              <p className="text-sm font-medium text-muted-foreground mb-1">Streak</p>
+              <p className="text-sm text-muted-foreground mb-2">
+                Tracking your streak requires an account to record each session.
+              </p>
+              <a href="/auth" className="text-sm text-primary hover:underline">Create a free account</a>
+            </div>
+
+            <div className="bg-muted/50 border border-border rounded-lg p-4">
+              <p className="text-sm font-medium text-muted-foreground mb-1">Weak Questions</p>
+              <p className="text-sm text-muted-foreground mb-2">
+                Identifying weak areas requires a history of your answers, which needs an account.
+              </p>
+              <a href="/auth" className="text-sm text-primary hover:underline">Create a free account</a>
+            </div>
+
+            <div className="bg-muted/50 border border-border rounded-lg p-4">
+              <p className="text-sm font-medium text-muted-foreground mb-1">Recent Tests</p>
+              <p className="text-sm text-muted-foreground mb-2">
+                Tracking your progress over time requires an account — there's nowhere to save it without one.
+              </p>
+              <a href="/auth" className="text-sm text-primary hover:underline">Create a free account</a>
+            </div>
+
+            <div className="bg-muted/50 border border-border rounded-lg p-4">
+              <p className="text-sm font-medium text-muted-foreground mb-1">Bookmarks</p>
+              <p className="text-sm text-muted-foreground mb-2">
+                Bookmarks need an account to persist — otherwise they disappear when you close the tab.
+              </p>
+              <a href="/auth" className="text-sm text-primary hover:underline">Create a free account</a>
+            </div>
+          </div>
+        </PageContainer>
+      );
+    }
 
     // Calculate weekly goal progress
     const questionsGoal = weeklyGoals?.questions_goal || 50;


### PR DESCRIPTION
…prompts

Dashboard no longer redirects unauthenticated users; guest placeholders render instead of auth-gated content. Auth page gains a "Continue as guest" option. Save-moment prompts (dismissible, non-blocking) appear at natural save points: after a practice test (TestResults), on bookmark click (QuestionCard), and on leaving a random practice session (RandomPractice).