### PR TITLE
fix: render figures in TopicQuiz (closes #194)

### DIFF
--- a/src/components/TopicQuiz.test.tsx
+++ b/src/components/TopicQuiz.test.tsx
@@ -228,6 +228,35 @@ describe('TopicQuiz', () => {
         expect(screen.getByRole('button', { name: /submit quiz with/i })).toBeInTheDocument();
       });
     });
+
+    it('renders the figure for questions that have a figureUrl (#194)', () => {
+      const questionWithFigure: Question = {
+        id: 'T6C02',
+        displayName: 'T6C02',
+        question: 'What is component 1 in figure T-1?',
+        options: { A: 'Resistor', B: 'Transistor', C: 'Battery', D: 'Connector' },
+        correctAnswer: 'A',
+        subelement: 'T6',
+        question_group: 'C',
+        license_type: 'technician',
+        explanation: null,
+        fcc_reference: null,
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+        figure_id: null,
+        figureUrl: '/figures/T-1.png',
+      };
+
+      render(
+        <TopicQuiz
+          questions={[questionWithFigure]}
+          onComplete={vi.fn()}
+          onDone={vi.fn()}
+        />
+      );
+
+      expect(screen.getByAltText('Figure for question T6C02')).toBeInTheDocument();
+    });
   });
 
   describe('Quiz Submission', () => {

--- a/src/components/TopicQuiz.tsx
+++ b/src/components/TopicQuiz.tsx
@@ -15,6 +15,7 @@ import {
   Loader2,
 } from "lucide-react";
 import { TOPIC_QUIZ_PASSING_THRESHOLD } from "@/types/navigation";
+import { FigureImage } from "@/components/FigureImage";
 
 interface TopicQuizProps {
   questions: Question[];
@@ -178,6 +179,12 @@ export function TopicQuiz({
             <h3 className="text-lg font-medium text-foreground leading-relaxed">
               {currentQuestion.question}
             </h3>
+
+            {/* Question Figure */}
+            <FigureImage
+              figureUrl={currentQuestion.figureUrl}
+              questionId={currentQuestion.id}
+            />
 
             {/* Options */}
             <div className="space-y-3">


### PR DESCRIPTION
## Summary
- Topic quizzes were missing schematic/diagram images, making figure-dependent questions (T6C02, T6C10, etc.) unanswerable
- `TopicQuiz.tsx` now renders `<FigureImage>` between the question text and answer options, mirroring the canonical pattern in `QuestionCard.tsx`
- `FigureImage` self-guards on `figureUrl` falsy, so the change is safe for every question with or without a figure

Closes #194

## Test plan
- [x] Added failing test in `TopicQuiz.test.tsx` for a question with `figureUrl` — verified RED (no `<img>` rendered) before applying fix, then GREEN after
- [x] Full `TopicQuiz.test.tsx` suite passes (29/29)
- [x] Lint clean on both changed files
- [ ] Manual verification: navigate to "Reading Schematics" topic → Take Quiz → confirm figures show on T6C02, T6C10, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)