### PR TITLE
fix: prevent silent wrong answers and broken round-trips in question import

### DIFF
--- a/src/components/admin/AdminQuestions.tsx
+++ b/src/components/admin/AdminQuestions.tsx
@@ -264,7 +264,7 @@ export function AdminQuestions({ testType, highlightQuestionId }: AdminQuestions
                 itemLabel="questions"
                 formatCSV={(items) => {
                   const header =
-                    'display_name,question,option_a,option_b,option_c,option_d,correct_answer,explanation';
+                    'id,question,option_a,option_b,option_c,option_d,correct_answer,subelement,question_group,explanation';
                   const rows = items.map((q) =>
                     [
                       escapeCSVField(q.display_name),
@@ -274,6 +274,8 @@ export function AdminQuestions({ testType, highlightQuestionId }: AdminQuestions
                       escapeCSVField(q.options[2]),
                       escapeCSVField(q.options[3]),
                       ['A', 'B', 'C', 'D'][q.correct_answer],
+                      escapeCSVField(q.display_name.substring(0, 2)), // subelement e.g. T1
+                      escapeCSVField(q.display_name.substring(0, 3)), // question_group e.g. T1A
                       escapeCSVField(q.explanation || ''),
                     ].join(',')
                   );

--- a/src/components/admin/AdminQuestions.tsx
+++ b/src/components/admin/AdminQuestions.tsx
@@ -74,6 +74,7 @@ export function AdminQuestions({ testType, highlightQuestionId }: AdminQuestions
         .select(
           `
           id, display_name, question, options, correct_answer,
+          subelement, question_group,
           links, explanation, edit_history, figure_url, forum_url,
           discourse_sync_status, discourse_sync_at, discourse_sync_error,
           arrl_chapter_id, arrl_page_reference,
@@ -273,9 +274,9 @@ export function AdminQuestions({ testType, highlightQuestionId }: AdminQuestions
                       escapeCSVField(q.options[1]),
                       escapeCSVField(q.options[2]),
                       escapeCSVField(q.options[3]),
-                      ['A', 'B', 'C', 'D'][q.correct_answer],
-                      escapeCSVField(q.display_name.substring(0, 2)), // subelement e.g. T1
-                      escapeCSVField(q.display_name.substring(0, 3)), // question_group e.g. T1A
+                      escapeCSVField(['A', 'B', 'C', 'D'][q.correct_answer]),
+                      escapeCSVField(q.subelement),
+                      escapeCSVField(q.question_group),
                       escapeCSVField(q.explanation || ''),
                     ].join(',')
                   );

--- a/src/components/admin/BulkImportQuestions.tsx
+++ b/src/components/admin/BulkImportQuestions.tsx
@@ -196,11 +196,12 @@ export function BulkImportQuestions({ testType }: BulkImportQuestionsProps) {
   };
 
   const mergeQuestion = (existing: ImportQuestion, incoming: ImportQuestion): ImportQuestion => {
+    const useIncomingOptions = incoming.options.every(o => o);
     return {
       id: existing.id,
       question: incoming.question || existing.question,
-      options: incoming.options.every(o => o) ? incoming.options : existing.options,
-      correct_answer: incoming.correct_answer,
+      options: useIncomingOptions ? incoming.options : existing.options,
+      correct_answer: useIncomingOptions ? incoming.correct_answer : existing.correct_answer,
       subelement: incoming.subelement || existing.subelement,
       question_group: incoming.question_group || existing.question_group,
       explanation: existing.explanation || incoming.explanation, // Keep existing if present

--- a/src/components/admin/BulkImportQuestions.tsx
+++ b/src/components/admin/BulkImportQuestions.tsx
@@ -25,6 +25,7 @@ import {
   parseCSV,
   parseJSON,
   validateQuestions,
+  mergeQuestion,
 } from "@/lib/questionImportParser";
 import { parseNCVECDocument, SyllabusEntry } from "@/lib/ncvecParser";
 
@@ -195,19 +196,6 @@ export function BulkImportQuestions({ testType }: BulkImportQuestionsProps) {
     }
   };
 
-  const mergeQuestion = (existing: ImportQuestion, incoming: ImportQuestion): ImportQuestion => {
-    const useIncomingOptions = incoming.options.every(o => o);
-    return {
-      id: existing.id,
-      question: incoming.question || existing.question,
-      options: useIncomingOptions ? incoming.options : existing.options,
-      correct_answer: useIncomingOptions ? incoming.correct_answer : existing.correct_answer,
-      subelement: incoming.subelement || existing.subelement,
-      question_group: incoming.question_group || existing.question_group,
-      explanation: existing.explanation || incoming.explanation, // Keep existing if present
-      links: (existing.links && existing.links.length > 0) ? existing.links : incoming.links, // Keep existing if present
-    };
-  };
 
   const handleConflictsResolved = async (resolvedConflicts: ConflictItem<ImportQuestion>[]) => {
     setConflicts(resolvedConflicts);

--- a/src/components/admin/questions/types.ts
+++ b/src/components/admin/questions/types.ts
@@ -16,6 +16,8 @@ export interface Question {
   question: string;
   options: string[];
   correct_answer: number;
+  subelement: string;      // e.g. T1, G2, E3
+  question_group: string;  // e.g. T1A, G2B, E3C
   links?: LinkData[];
   explanation?: string | null;
   edit_history?: EditHistoryEntry[];

--- a/src/lib/questionImportParser.test.ts
+++ b/src/lib/questionImportParser.test.ts
@@ -4,6 +4,7 @@ import {
   parseCSV,
   parseJSON,
   validateQuestions,
+  mergeQuestion,
   ImportQuestion,
   TEST_TYPE_PREFIXES,
 } from './questionImportParser';
@@ -114,6 +115,31 @@ T1A01,"What is 1, 2, and 3?","A, first","B, second","C, third","D, fourth",A,T1,
     const result = parseCSV(csv);
     expect(result[0].question).toBe('What is 1, 2, and 3?');
     expect(result[0].options[0]).toBe('A, first');
+  });
+
+  it('accepts display_name column as fallback for id (export round-trip)', () => {
+    const csv = `display_name,question,option_a,option_b,option_c,option_d,correct_answer,subelement,question_group
+T1A01,"Test question?","Option A","Option B","Option C","Option D",C,T1,T1A`;
+
+    const result = parseCSV(csv);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('T1A01');
+    expect(result[0].correct_answer).toBe(2);
+  });
+
+  it('fails validation when correct_answer is empty or unrecognized', () => {
+    const csv = `id,question,option_a,option_b,option_c,option_d,correct_answer,subelement,question_group
+T1A01,"Test?","A","B","C","D",,T1,T1A
+T1A02,"Test?","A","B","C","D",B. Some full text,T1,T1A`;
+
+    const parsed = parseCSV(csv);
+    expect(parsed[0].correct_answer).toBe(-1);
+    expect(parsed[1].correct_answer).toBe(-1);
+
+    const { errors } = validateQuestions(parsed, 'technician');
+    expect(errors).toHaveLength(2);
+    expect(errors[0].errors[0]).toContain('Could not parse correct_answer');
+    expect(errors[1].errors[0]).toContain('Could not parse correct_answer');
   });
 });
 
@@ -437,6 +463,58 @@ describe('validateQuestions', () => {
     const result = validateQuestions([lowercaseId], 'technician');
     expect(result.valid).toHaveLength(1);
     expect(result.valid[0].id).toBe('T1A01'); // Normalized to uppercase
+  });
+});
+
+describe('mergeQuestion', () => {
+  const existing: ImportQuestion = {
+    id: 'T1A01',
+    question: 'Old question?',
+    options: ['Old A', 'Old B', 'Old C', 'Old D'],
+    correct_answer: 2,
+    subelement: 'T1',
+    question_group: 'T1A',
+    explanation: 'Old explanation',
+    links: [{ url: 'https://example.com', title: 'Link' } as never],
+  };
+
+  it('uses incoming options and correct_answer when all incoming options are present', () => {
+    const incoming: ImportQuestion = {
+      ...existing,
+      options: ['New A', 'New B', 'New C', 'New D'],
+      correct_answer: 3,
+    };
+    const merged = mergeQuestion(existing, incoming);
+    expect(merged.options).toEqual(['New A', 'New B', 'New C', 'New D']);
+    expect(merged.correct_answer).toBe(3);
+  });
+
+  it('falls back to existing options AND existing correct_answer when incoming options are incomplete', () => {
+    const incoming: ImportQuestion = {
+      ...existing,
+      options: ['New A', '', 'New C', 'New D'], // one empty → incomplete
+      correct_answer: 1, // would be wrong relative to existing options
+    };
+    const merged = mergeQuestion(existing, incoming);
+    expect(merged.options).toEqual(['Old A', 'Old B', 'Old C', 'Old D']);
+    expect(merged.correct_answer).toBe(2); // comes from existing, not incoming
+  });
+
+  it('keeps existing explanation and links when present', () => {
+    const incoming: ImportQuestion = {
+      ...existing,
+      explanation: 'New explanation',
+      links: [],
+    };
+    const merged = mergeQuestion(existing, incoming);
+    expect(merged.explanation).toBe('Old explanation');
+    expect(merged.links).toEqual(existing.links);
+  });
+
+  it('uses incoming question text when incoming has text', () => {
+    const incoming: ImportQuestion = { ...existing, question: 'New question?' };
+    const merged = mergeQuestion(existing, incoming);
+    expect(merged.question).toBe('New question?');
   });
 });
 

--- a/src/lib/questionImportParser.test.ts
+++ b/src/lib/questionImportParser.test.ts
@@ -362,10 +362,16 @@ describe('validateQuestions', () => {
     expect(result.errors[0].errors).toContain('All options must have text');
   });
 
-  it('rejects questions with invalid correct_answer', () => {
+  it('rejects questions with out-of-range correct_answer', () => {
     const invalidAnswer = { ...validQuestion, correct_answer: 5 };
     const result = validateQuestions([invalidAnswer], 'technician');
-    expect(result.errors[0].errors).toContain('Invalid correct answer');
+    expect(result.errors[0].errors).toContain('Invalid correct answer (must be 0–3)');
+  });
+
+  it('rejects questions with unparseable correct_answer (-1 sentinel)', () => {
+    const unparsed = { ...validQuestion, correct_answer: -1 };
+    const result = validateQuestions([unparsed], 'technician');
+    expect(result.errors[0].errors).toContain('Could not parse correct_answer — use A/B/C/D or 0/1/2/3');
   });
 
   it('rejects questions with missing subelement', () => {

--- a/src/lib/questionImportParser.ts
+++ b/src/lib/questionImportParser.ts
@@ -181,3 +181,21 @@ export function validateQuestions(
 
   return { valid, errors };
 }
+
+/**
+ * Merge an incoming question over an existing one.
+ * Options and correct_answer always come from the same source so they stay aligned.
+ */
+export function mergeQuestion(existing: ImportQuestion, incoming: ImportQuestion): ImportQuestion {
+  const useIncomingOptions = incoming.options.every(o => o);
+  return {
+    id: existing.id,
+    question: incoming.question || existing.question,
+    options: useIncomingOptions ? incoming.options : existing.options,
+    correct_answer: useIncomingOptions ? incoming.correct_answer : existing.correct_answer,
+    subelement: incoming.subelement || existing.subelement,
+    question_group: incoming.question_group || existing.question_group,
+    explanation: existing.explanation || incoming.explanation,
+    links: (existing.links && existing.links.length > 0) ? existing.links : incoming.links,
+  };
+}

--- a/src/lib/questionImportParser.ts
+++ b/src/lib/questionImportParser.ts
@@ -72,14 +72,14 @@ export function parseCSV(content: string): ImportQuestion[] {
     };
 
     const correctAnswerRaw = getCol('correct_answer') || getCol('correct');
-    let correctAnswer = 0;
+    let correctAnswer = -1; // -1 = could not parse; fails validation
     if (['a', '0'].includes(correctAnswerRaw.toLowerCase())) correctAnswer = 0;
     else if (['b', '1'].includes(correctAnswerRaw.toLowerCase())) correctAnswer = 1;
     else if (['c', '2'].includes(correctAnswerRaw.toLowerCase())) correctAnswer = 2;
     else if (['d', '3'].includes(correctAnswerRaw.toLowerCase())) correctAnswer = 3;
 
     questions.push({
-      id: getCol('id'),
+      id: getCol('id') || getCol('display_name'),
       question: getCol('question'),
       options: [
         getCol('option_a') || getCol('a'),
@@ -122,7 +122,7 @@ export function parseJSON(content: string): ImportQuestion[] {
         ['a', '0'].includes(String(q.correct_answer).toLowerCase()) ? 0 :
         ['b', '1'].includes(String(q.correct_answer).toLowerCase()) ? 1 :
         ['c', '2'].includes(String(q.correct_answer).toLowerCase()) ? 2 :
-        ['d', '3'].includes(String(q.correct_answer).toLowerCase()) ? 3 : 0,
+        ['d', '3'].includes(String(q.correct_answer).toLowerCase()) ? 3 : -1,
       subelement: String(q.subelement || ''),
       question_group: String(q.question_group || q.group || ''),
       explanation: q.explanation ? String(q.explanation) : undefined,
@@ -159,7 +159,8 @@ export function validateQuestions(
     if (!q.options || q.options.length !== 4) rowErrors.push('Must have exactly 4 options');
     else if (q.options.some(o => !o?.trim())) rowErrors.push('All options must have text');
 
-    if (q.correct_answer < 0 || q.correct_answer > 3) rowErrors.push('Invalid correct answer');
+    if (q.correct_answer === -1) rowErrors.push('Could not parse correct_answer — use A/B/C/D or 0/1/2/3');
+    else if (q.correct_answer < 0 || q.correct_answer > 3) rowErrors.push('Invalid correct answer (must be 0–3)');
     if (!q.subelement) rowErrors.push('Missing subelement');
     if (!q.question_group) rowErrors.push('Missing question group');
 


### PR DESCRIPTION
## Summary

- **Silent wrong answer bug**: `correct_answer` parser defaulted to `0` (option A) when the field was empty, missing, or in an unrecognized format — with no error or warning. Now defaults to `-1`, which fails validation with a descriptive message: *"Could not parse correct_answer — use A/B/C/D or 0/1/2/3"*
- **Export/import round-trip broken**: CSV export used `display_name` as the column header but import only accepted `id`, so every re-imported question failed with "Missing ID". Export also omitted required `subelement` and `question_group` columns. Fixed the export header and added the missing columns; importer now also accepts `display_name` as a fallback for the `id` column
- **Merge conflict mismatch**: When resolving a conflict as "merge" and incoming options were incomplete (falling back to existing), `correct_answer` still came from the incoming data (potentially the wrong default). Options and answer now always come from the same source

## Test plan

- [x] All 3492 existing tests pass (`npm run test:run`)
- [x] Lint clean — 0 errors (`npm run lint`)
- [ ] Export questions as CSV from admin, re-import the file — should succeed with no errors
- [ ] Import a CSV with a blank or malformed `correct_answer` column — should show a validation error per row instead of silently importing with answer A
- [ ] Import a CSV with `correct_answer` as full answer text (e.g. `"B. Some text"`) — should show a clear parse error
- [ ] Test merge conflict resolution with a partially-filled incoming import — answer should stay aligned with whichever option set is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)