### PR TITLE
fix: address remaining medium and low security findings (M1, M3-M7, L1-L5)

### DIFF
--- a/scripts/migrate-topic-content.ts
+++ b/scripts/migrate-topic-content.ts
@@ -18,12 +18,14 @@
 import { createClient } from "@supabase/supabase-js";
 import * as readline from "readline";
 
-// Use environment variables or defaults for local development
+// Require env vars — no key fallback so a misconfigured SUPABASE_URL=<prod> never
+// silently falls through to the well-known local demo key.
 const supabaseUrl = process.env.SUPABASE_URL || "http://127.0.0.1:54321";
-const supabaseKey =
-  process.env.SUPABASE_SERVICE_ROLE_KEY ||
-  process.env.SUPABASE_ANON_KEY ||
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU";
+const supabaseKey = (process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY) as string;
+if (!supabaseKey) {
+  console.error("Error: SUPABASE_SERVICE_ROLE_KEY or SUPABASE_ANON_KEY must be set.");
+  process.exit(1);
+}
 
 // Check if running against production by parsing the URL properly
 function isProductionUrl(url: string): boolean {

--- a/src/components/admin/AdminGlossary.tsx
+++ b/src/components/admin/AdminGlossary.tsx
@@ -70,9 +70,10 @@ export function AdminGlossary() {
 
   const addTerm = useMutation({
     mutationFn: async ({ term, definition }: { term: string; definition: string }) => {
+      if (!user) throw new Error('Not authenticated');
       const historyEntry: EditHistoryEntry = {
-        user_id: user?.id || '',
-        user_email: user?.email || 'Unknown',
+        user_id: user.id,
+        user_email: user.email || 'Unknown',
         action: 'created',
         changes: {},
         timestamp: new Date().toISOString(),
@@ -103,6 +104,7 @@ export function AdminGlossary() {
 
   const updateTerm = useMutation({
     mutationFn: async ({ id, term, definition, originalTerm }: { id: string; term: string; definition: string; originalTerm: GlossaryTerm }) => {
+      if (!user) throw new Error('Not authenticated');
       // Build changes object
       const changes: Record<string, { from: unknown; to: unknown }> = {};
       if (originalTerm.term !== term.trim()) {
@@ -113,8 +115,8 @@ export function AdminGlossary() {
       }
 
       const historyEntry: EditHistoryEntry = {
-        user_id: user?.id || '',
-        user_email: user?.email || 'Unknown',
+        user_id: user.id,
+        user_email: user.email || 'Unknown',
         action: 'updated',
         changes,
         timestamp: new Date().toISOString(),

--- a/src/components/admin/AdminHamRadioTools.tsx
+++ b/src/components/admin/AdminHamRadioTools.tsx
@@ -95,7 +95,7 @@ export function AdminHamRadioTools() {
       toast.error("Please fill in title, description, and URL");
       return;
     }
-    if (!user) { console.warn('[AdminHamRadioTools] handleAddTool called without authenticated user'); return; }
+    if (!user) { toast.error('Your session has expired. Please sign in again.'); return; }
 
     const historyEntry: EditHistoryEntry = {
       user_id: user.id,
@@ -149,7 +149,7 @@ export function AdminHamRadioTools() {
       toast.error("Please fill in title, description, and URL");
       return;
     }
-    if (!user) { console.warn('[AdminHamRadioTools] handleUpdateTool called without authenticated user'); return; }
+    if (!user) { toast.error('Your session has expired. Please sign in again.'); return; }
 
     // Build changes object for edit history
     const changes: Record<string, { from: unknown; to: unknown }> = {};

--- a/src/components/admin/AdminHamRadioTools.tsx
+++ b/src/components/admin/AdminHamRadioTools.tsx
@@ -95,7 +95,7 @@ export function AdminHamRadioTools() {
       toast.error("Please fill in title, description, and URL");
       return;
     }
-    if (!user) return;
+    if (!user) { console.warn('[AdminHamRadioTools] handleAddTool called without authenticated user'); return; }
 
     const historyEntry: EditHistoryEntry = {
       user_id: user.id,
@@ -149,7 +149,7 @@ export function AdminHamRadioTools() {
       toast.error("Please fill in title, description, and URL");
       return;
     }
-    if (!user) return;
+    if (!user) { console.warn('[AdminHamRadioTools] handleUpdateTool called without authenticated user'); return; }
 
     // Build changes object for edit history
     const changes: Record<string, { from: unknown; to: unknown }> = {};

--- a/src/components/admin/AdminHamRadioTools.tsx
+++ b/src/components/admin/AdminHamRadioTools.tsx
@@ -95,10 +95,11 @@ export function AdminHamRadioTools() {
       toast.error("Please fill in title, description, and URL");
       return;
     }
+    if (!user) return;
 
     const historyEntry: EditHistoryEntry = {
-      user_id: user?.id || "",
-      user_email: user?.email || "Unknown",
+      user_id: user.id,
+      user_email: user.email || "Unknown",
       action: "created",
       changes: {},
       timestamp: new Date().toISOString(),
@@ -148,6 +149,7 @@ export function AdminHamRadioTools() {
       toast.error("Please fill in title, description, and URL");
       return;
     }
+    if (!user) return;
 
     // Build changes object for edit history
     const changes: Record<string, { from: unknown; to: unknown }> = {};
@@ -171,8 +173,8 @@ export function AdminHamRadioTools() {
     }
 
     const historyEntry: EditHistoryEntry = {
-      user_id: user?.id || "",
-      user_email: user?.email || "Unknown",
+      user_id: user.id,
+      user_email: user.email || "Unknown",
       action: "updated",
       changes,
       timestamp: new Date().toISOString(),

--- a/src/components/admin/AdminLessons.tsx
+++ b/src/components/admin/AdminLessons.tsx
@@ -82,7 +82,7 @@ export function AdminLessons() {
       toast.error("A lesson with this slug already exists");
       return;
     }
-    if (!user) { console.warn('[AdminLessons] handleAddLesson called without authenticated user'); return; }
+    if (!user) { toast.error('Your session has expired. Please sign in again.'); return; }
 
     const historyEntry: EditHistoryEntry = {
       user_id: user.id,

--- a/src/components/admin/AdminLessons.tsx
+++ b/src/components/admin/AdminLessons.tsx
@@ -82,7 +82,7 @@ export function AdminLessons() {
       toast.error("A lesson with this slug already exists");
       return;
     }
-    if (!user) return;
+    if (!user) { console.warn('[AdminLessons] handleAddLesson called without authenticated user'); return; }
 
     const historyEntry: EditHistoryEntry = {
       user_id: user.id,

--- a/src/components/admin/AdminLessons.tsx
+++ b/src/components/admin/AdminLessons.tsx
@@ -82,10 +82,11 @@ export function AdminLessons() {
       toast.error("A lesson with this slug already exists");
       return;
     }
+    if (!user) return;
 
     const historyEntry: EditHistoryEntry = {
-      user_id: user?.id || "",
-      user_email: user?.email || "Unknown",
+      user_id: user.id,
+      user_email: user.email || "Unknown",
       action: "created",
       changes: {},
       timestamp: new Date().toISOString(),

--- a/src/components/admin/AdminTopics.tsx
+++ b/src/components/admin/AdminTopics.tsx
@@ -73,9 +73,10 @@ export function AdminTopics() {
       license_types: string[];
       is_published: boolean;
     }) => {
+      if (!user) throw new Error('Not authenticated');
       const historyEntry: EditHistoryEntry = {
-        user_id: user?.id || "",
-        user_email: user?.email || "Unknown",
+        user_id: user.id,
+        user_email: user.email || "Unknown",
         action: "created",
         changes: {},
         timestamp: new Date().toISOString(),

--- a/src/components/admin/LessonEditor.tsx
+++ b/src/components/admin/LessonEditor.tsx
@@ -85,7 +85,7 @@ export function LessonEditor({ lesson, onBack }: LessonEditorProps) {
       toast.error("Slug is required");
       return;
     }
-    if (!user) return;
+    if (!user) { toast.error('Your session has expired. Please sign in again.'); return; }
 
     const changes: Record<string, { from: unknown; to: unknown }> = {};
     if (title !== lesson.title) changes.title = { from: lesson.title, to: title };
@@ -142,7 +142,7 @@ export function LessonEditor({ lesson, onBack }: LessonEditorProps) {
   };
 
   const handleTogglePublish = () => {
-    if (!user) return;
+    if (!user) { toast.error('Your session has expired. Please sign in again.'); return; }
     const previousState = isPublished;
     const newPublished = !previousState;
     setIsPublished(newPublished);

--- a/src/components/admin/LessonEditor.tsx
+++ b/src/components/admin/LessonEditor.tsx
@@ -85,6 +85,7 @@ export function LessonEditor({ lesson, onBack }: LessonEditorProps) {
       toast.error("Slug is required");
       return;
     }
+    if (!user) return;
 
     const changes: Record<string, { from: unknown; to: unknown }> = {};
     if (title !== lesson.title) changes.title = { from: lesson.title, to: title };
@@ -97,8 +98,8 @@ export function LessonEditor({ lesson, onBack }: LessonEditorProps) {
     if (displayOrder !== lesson.display_order) changes.display_order = { from: lesson.display_order, to: displayOrder };
 
     const historyEntry: EditHistoryEntry = {
-      user_id: user?.id || "",
-      user_email: user?.email || "Unknown",
+      user_id: user.id,
+      user_email: user.email || "Unknown",
       action: "updated",
       changes,
       timestamp: new Date().toISOString(),
@@ -141,14 +142,15 @@ export function LessonEditor({ lesson, onBack }: LessonEditorProps) {
   };
 
   const handleTogglePublish = () => {
+    if (!user) return;
     const previousState = isPublished;
     const newPublished = !previousState;
     setIsPublished(newPublished);
 
     // Auto-save publish status
     const historyEntry: EditHistoryEntry = {
-      user_id: user?.id || "",
-      user_email: user?.email || "Unknown",
+      user_id: user.id,
+      user_email: user.email || "Unknown",
       action: "updated",
       changes: { is_published: { from: previousState, to: newPublished } },
       timestamp: new Date().toISOString(),

--- a/src/components/admin/TopicEditor.tsx
+++ b/src/components/admin/TopicEditor.tsx
@@ -91,6 +91,7 @@ export function TopicEditor({ topic, onBack }: TopicEditorProps) {
 
   const updateSettingsMutation = useMutation({
     mutationFn: async () => {
+      if (!user) throw new Error('Not authenticated');
       const changes: Record<string, { from: unknown; to: unknown }> = {};
 
       if (topic.title !== title.trim()) {
@@ -113,8 +114,8 @@ export function TopicEditor({ topic, onBack }: TopicEditorProps) {
       }
 
       const historyEntry: EditHistoryEntry = {
-        user_id: user?.id || "",
-        user_email: user?.email || "Unknown",
+        user_id: user.id,
+        user_email: user.email || "Unknown",
         action: "updated",
         changes,
         timestamp: new Date().toISOString(),

--- a/src/hooks/useOAuthConsent.test.tsx
+++ b/src/hooks/useOAuthConsent.test.tsx
@@ -178,7 +178,8 @@ describe('useOAuthConsent', () => {
   });
 
   describe('Auto-approve with existing forum username', () => {
-    it('should auto-approve when user has existing forum username', async () => {
+    it('should auto-approve when user has existing forum username and client is trusted', async () => {
+      vi.stubEnv('VITE_TRUSTED_OAUTH_CLIENT_IDS', 'test-client');
       const originalLocation = window.location;
       // @ts-expect-error - mocking window.location
       delete window.location;
@@ -206,6 +207,35 @@ describe('useOAuthConsent', () => {
       expect(mockApproveAuthorization).toHaveBeenCalledWith('test-auth-id');
 
       window.location = originalLocation;
+      vi.unstubAllEnvs();
+    });
+
+    it('should show consent form (not auto-approve) when client is not in trusted list', async () => {
+      vi.stubEnv('VITE_TRUSTED_OAUTH_CLIENT_IDS', 'other-client');
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'profiles') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn(() => Promise.resolve({ data: { forum_username: 'existinguser' }, error: null })),
+              })),
+            })),
+          };
+        }
+        return {};
+      });
+
+      const { result } = renderHook(() => useOAuthConsent(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.isAutoApproving).toBe(false);
+      expect(mockApproveAuthorization).not.toHaveBeenCalled();
+
+      vi.unstubAllEnvs();
     });
 
     it('should show username form when user has no forum username', async () => {

--- a/src/hooks/useOAuthConsent.ts
+++ b/src/hooks/useOAuthConsent.ts
@@ -173,7 +173,7 @@ export function useOAuthConsent(): UseOAuthConsentReturn {
         .split(',')
         .map((id: string) => id.trim())
         .filter(Boolean);
-      const isTrustedClient = trustedIds.length > 0 && trustedIds.includes(clientId);
+      const isTrustedClient = trustedIds.includes(clientId);
 
       if (userForumUsername && isTrustedClient) {
         await autoApprove(authId);

--- a/src/hooks/useOAuthConsent.ts
+++ b/src/hooks/useOAuthConsent.ts
@@ -165,8 +165,17 @@ export function useOAuthConsent(): UseOAuthConsentReturn {
       const userForumUsername = profileData?.forum_username || null;
       setForumUsername(userForumUsername);
 
-      // If user already has a forum username, auto-approve (no consent needed - we own both apps)
-      if (userForumUsername) {
+      // Auto-approve only for first-party clients (Discourse forum integration).
+      // VITE_TRUSTED_OAUTH_CLIENT_IDS is a comma-separated list of client_id values
+      // that may be silently approved. If the env var is not set, always show the
+      // consent screen so the user is aware of what they're authorizing.
+      const trustedIds = (import.meta.env.VITE_TRUSTED_OAUTH_CLIENT_IDS || '')
+        .split(',')
+        .map((id: string) => id.trim())
+        .filter(Boolean);
+      const isTrustedClient = trustedIds.length > 0 && trustedIds.includes(clientId);
+
+      if (userForumUsername && isTrustedClient) {
         await autoApprove(authId);
         return;
       }

--- a/supabase/functions/_shared/constants.ts
+++ b/supabase/functions/_shared/constants.ts
@@ -230,7 +230,7 @@ export function errorResponse(
   err?: unknown,
   corsHeaders?: Record<string, string>
 ): Response {
-  if (err !== undefined) console.error(message, err);
+  if (err != null) console.error(message, err);
   return new Response(
     JSON.stringify({ error: message }),
     { status, headers: { 'Content-Type': 'application/json', ...(corsHeaders ?? {}) } }
@@ -245,12 +245,13 @@ export function errorResponse(
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function requireAdmin(supabase: any, userId: string): Promise<boolean> {
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from('user_roles')
     .select('role')
     .eq('user_id', userId)
     .eq('role', 'admin')
     .maybeSingle();
+  if (error) console.error('[requireAdmin] DB error:', error);
   return Boolean(data);
 }
 

--- a/supabase/functions/_shared/constants.ts
+++ b/supabase/functions/_shared/constants.ts
@@ -217,6 +217,43 @@ export function isServiceRoleToken(token: string): boolean {
   return payload?.role === 'service_role';
 }
 
+/**
+ * Return a safe error Response that logs full detail server-side but only
+ * sends a generic message to the caller. Use for all unhandled catch blocks.
+ *
+ * For 4xx responses where the message is intentional (e.g. "Unauthorized",
+ * "Question not found") keep the specific message and skip this helper.
+ */
+export function errorResponse(
+  message: string,
+  status: number,
+  err?: unknown,
+  corsHeaders?: Record<string, string>
+): Response {
+  if (err !== undefined) console.error(message, err);
+  return new Response(
+    JSON.stringify({ error: message }),
+    { status, headers: { 'Content-Type': 'application/json', ...(corsHeaders ?? {}) } }
+  );
+}
+
+/**
+ * Check whether the authenticated user has the admin role.
+ * Returns true if admin, false otherwise (including on DB error).
+ * Uses maybeSingle + eq('role','admin') so it works regardless of
+ * how many roles the user has and doesn't throw on "no rows".
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function requireAdmin(supabase: any, userId: string): Promise<boolean> {
+  const { data } = await supabase
+    .from('user_roles')
+    .select('role')
+    .eq('user_id', userId)
+    .eq('role', 'admin')
+    .maybeSingle();
+  return Boolean(data);
+}
+
 // ============================================================
 // System Monitoring Constants
 // ============================================================

--- a/supabase/functions/delete-discourse-user/index.ts
+++ b/supabase/functions/delete-discourse-user/index.ts
@@ -1,5 +1,5 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "jsr:@supabase/supabase-js@2";
 import { getCorsHeaders } from "../_shared/constants.ts";
 import {
   buildUserLookupUrl,
@@ -183,7 +183,7 @@ async function deleteDiscourseUser(
   }
 }
 
-serve(async (req) => {
+Deno.serve(async (req: Request) => {
   const requestId = crypto.randomUUID().slice(0, 8);
   const corsHeaders = getCorsHeaders(req);
 

--- a/supabase/functions/discourse-webhook/index.ts
+++ b/supabase/functions/discourse-webhook/index.ts
@@ -1,6 +1,6 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { isValidUuid, getCorsHeaders } from "../_shared/constants.ts";
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "jsr:@supabase/supabase-js@2";
+import { isValidUuid, getCorsHeaders, errorResponse } from "../_shared/constants.ts";
 import {
   parseExplanationFromPost,
   extractQuestionIdFromTitle,
@@ -102,7 +102,7 @@ interface DiscourseTopic {
 // MAIN HANDLER
 // =============================================================================
 
-serve(async (req) => {
+Deno.serve(async (req: Request) => {
   const requestId = crypto.randomUUID().slice(0, 8);
   const corsHeaders = {
     ...getCorsHeaders(req),
@@ -470,11 +470,6 @@ serve(async (req) => {
       { headers: { ...corsHeaders, "Content-Type": "application/json" } }
     );
   } catch (error) {
-    console.error(`[${requestId}] Webhook handler error:`, error);
-    const errorMessage = error instanceof Error ? error.message : "Unknown error";
-    return new Response(JSON.stringify({ error: errorMessage }), {
-      status: 500,
-      headers: { ...corsHeaders, "Content-Type": "application/json" },
-    });
+    return errorResponse('Internal server error', 500, error, corsHeaders);
   }
 });

--- a/supabase/functions/discourse-webhook/index.ts
+++ b/supabase/functions/discourse-webhook/index.ts
@@ -470,6 +470,7 @@ Deno.serve(async (req: Request) => {
       { headers: { ...corsHeaders, "Content-Type": "application/json" } }
     );
   } catch (error) {
-    return errorResponse('Internal server error', 500, error, corsHeaders);
+    console.error(`[${requestId}] Unhandled error:`, error);
+    return errorResponse('Internal server error', 500, undefined, corsHeaders);
   }
 });

--- a/supabase/functions/manage-question-links/index.ts
+++ b/supabase/functions/manage-question-links/index.ts
@@ -466,6 +466,7 @@ Deno.serve(async (req) => {
     );
 
   } catch (error) {
-    return errorResponse('Internal server error', 500, error, corsHeaders);
+    console.error(`[${requestId}] Unhandled error:`, error);
+    return errorResponse('Internal server error', 500, undefined, corsHeaders);
   }
 });

--- a/supabase/functions/manage-question-links/index.ts
+++ b/supabase/functions/manage-question-links/index.ts
@@ -1,7 +1,9 @@
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "jsr:@supabase/supabase-js@2";
 import {
   getCorsHeaders,
   isServiceRoleToken,
+  errorResponse,
 } from "../_shared/constants.ts";
 import {
   extractMetaContent,
@@ -464,11 +466,6 @@ Deno.serve(async (req) => {
     );
 
   } catch (error) {
-    console.error(`[${requestId}] Error:`, error);
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    return new Response(
-      JSON.stringify({ error: errorMessage }),
-      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-    );
+    return errorResponse('Internal server error', 500, error, corsHeaders);
   }
 });

--- a/supabase/functions/migrate-discourse-external-ids/index.ts
+++ b/supabase/functions/migrate-discourse-external-ids/index.ts
@@ -523,6 +523,7 @@ Deno.serve(async (req: Request) => {
       { headers: { ...corsHeaders, "Content-Type": "application/json" } }
     );
   } catch (error) {
-    return errorResponse('Internal server error', 500, error, corsHeaders);
+    console.error(`[${requestId}] Unhandled error:`, error);
+    return errorResponse('Internal server error', 500, undefined, corsHeaders);
   }
 });

--- a/supabase/functions/migrate-discourse-external-ids/index.ts
+++ b/supabase/functions/migrate-discourse-external-ids/index.ts
@@ -1,9 +1,10 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "jsr:@supabase/supabase-js@2";
 import {
   corsHeaders,
   DISCOURSE_URL,
   isServiceRoleToken,
+  errorResponse,
 } from "../_shared/constants.ts";
 import {
   isValidDiscourseUrl,
@@ -119,7 +120,7 @@ async function updateTopicExternalIdWithRetry(
   return { success: false, error: "Max retries exceeded" };
 }
 
-serve(async (req) => {
+Deno.serve(async (req: Request) => {
   const requestId = crypto.randomUUID().slice(0, 8);
 
   // Handle CORS preflight
@@ -522,12 +523,6 @@ serve(async (req) => {
       { headers: { ...corsHeaders, "Content-Type": "application/json" } }
     );
   } catch (error) {
-    console.error(`[${requestId}] Error:`, error);
-    const errorMessage =
-      error instanceof Error ? error.message : "Unknown error";
-    return new Response(JSON.stringify({ error: errorMessage }), {
-      status: 500,
-      headers: { ...corsHeaders, "Content-Type": "application/json" },
-    });
+    return errorResponse('Internal server error', 500, error, corsHeaders);
   }
 });

--- a/supabase/functions/question-opengraph/index.ts
+++ b/supabase/functions/question-opengraph/index.ts
@@ -179,6 +179,7 @@ Deno.serve(async (req: Request) => {
     });
 
   } catch (error) {
-    return errorResponse('Internal server error', 500, error, corsHeaders);
+    console.error(`[${requestId}] Unhandled error:`, error);
+    return errorResponse('Internal server error', 500, undefined, corsHeaders);
   }
 });

--- a/supabase/functions/question-opengraph/index.ts
+++ b/supabase/functions/question-opengraph/index.ts
@@ -1,6 +1,6 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { getCorsHeaders } from "../_shared/constants.ts";
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "jsr:@supabase/supabase-js@2";
+import { getCorsHeaders, errorResponse } from "../_shared/constants.ts";
 import {
   truncateText,
   isCrawler,
@@ -16,7 +16,7 @@ const SITE_NAME = 'Open Ham Prep';
 const DEFAULT_IMAGE = `${SITE_URL}/icons/icon-512.png`;
 const MAX_DESCRIPTION_LENGTH = 200;
 
-serve(async (req) => {
+Deno.serve(async (req: Request) => {
   const requestId = crypto.randomUUID().slice(0, 8);
   const corsHeaders = getCorsHeaders(req);
   const userAgent = req.headers.get('user-agent');
@@ -179,11 +179,6 @@ serve(async (req) => {
     });
 
   } catch (error) {
-    console.error(`[${requestId}] Error generating OpenGraph HTML:`, error);
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    return new Response(`Internal server error: ${errorMessage}`, {
-      status: 500,
-      headers: corsHeaders,
-    });
+    return errorResponse('Internal server error', 500, error, corsHeaders);
   }
 });

--- a/supabase/functions/sync-discourse-topics/index.ts
+++ b/supabase/functions/sync-discourse-topics/index.ts
@@ -1,5 +1,5 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "jsr:@supabase/supabase-js@2";
 import {
   corsHeaders,
   DISCOURSE_URL,
@@ -9,6 +9,8 @@ import {
   getCategorySlug,
   isServiceRoleToken,
   fetchWithBackoff,
+  errorResponse,
+  requireAdmin,
 } from "../_shared/constants.ts";
 import {
   formatTopicBody,
@@ -256,7 +258,7 @@ async function createDiscourseTopic(
   }
 }
 
-serve(async (req) => {
+Deno.serve(async (req: Request) => {
   const requestId = crypto.randomUUID().slice(0, 8);
 
   if (req.method === 'OPTIONS') {
@@ -301,13 +303,8 @@ serve(async (req) => {
       }
 
       // Verify user has admin role
-      const { data: roleData, error: roleError } = await supabase
-        .from('user_roles')
-        .select('role')
-        .eq('user_id', user.id)
-        .single();
-
-      if (roleError || roleData?.role !== 'admin') {
+      const isAdmin = await requireAdmin(supabase, user.id);
+      if (!isAdmin) {
         return new Response(
           JSON.stringify({ error: 'Forbidden: Admin access required' }),
           { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
@@ -623,11 +620,6 @@ serve(async (req) => {
     );
 
   } catch (error) {
-    console.error(`[${requestId}] Error:`, error);
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    return new Response(
-      JSON.stringify({ error: errorMessage }),
-      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-    );
+    return errorResponse('Internal server error', 500, error, corsHeaders);
   }
 });

--- a/supabase/functions/update-discourse-post/index.ts
+++ b/supabase/functions/update-discourse-post/index.ts
@@ -85,6 +85,10 @@ Deno.serve(async (req: Request) => {
     return new Response("ok", { headers: corsHeaders });
   }
 
+  // Hoisted outside try so the catch block can write discourse_sync_error
+  // after req.json() consumes the body (req.clone() would throw at that point).
+  let parsedQuestionId: string | undefined;
+
   try {
     console.log(`[${requestId}] update-discourse-post: Request received`);
 
@@ -156,9 +160,7 @@ Deno.serve(async (req: Request) => {
 
     const body: RequestBody = await req.json();
     const { questionId, explanation } = body;
-    // Captured here so the catch block can write discourse_sync_error without
-    // re-reading the already-consumed request body via req.clone().
-    const parsedQuestionId: string | undefined = questionId || undefined;
+    parsedQuestionId = questionId || undefined;
 
     if (!questionId) {
       console.warn(`[${requestId}] Missing questionId`);

--- a/supabase/functions/update-discourse-post/index.ts
+++ b/supabase/functions/update-discourse-post/index.ts
@@ -156,6 +156,9 @@ Deno.serve(async (req: Request) => {
 
     const body: RequestBody = await req.json();
     const { questionId, explanation } = body;
+    // Captured here so the catch block can write discourse_sync_error without
+    // re-reading the already-consumed request body via req.clone().
+    const parsedQuestionId: string | undefined = questionId || undefined;
 
     if (!questionId) {
       console.warn(`[${requestId}] Missing questionId`);
@@ -416,11 +419,11 @@ Deno.serve(async (req: Request) => {
     console.error(`[${requestId}] Update Discourse post error:`, error);
     const errorMessage = error instanceof Error ? error.message : "Unknown error";
 
-    // Try to update the sync status to error
-    try {
-      const bodyText = await req.clone().text();
-      const body = JSON.parse(bodyText);
-      if (body.questionId) {
+    // Try to update the sync status to error using parsedQuestionId captured
+    // before the try block — req.json() consumes the body, so req.clone() here
+    // would throw "Body is unusable".
+    if (parsedQuestionId) {
+      try {
         const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
         const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
         const supabase = createClient(supabaseUrl, supabaseKey);
@@ -428,12 +431,12 @@ Deno.serve(async (req: Request) => {
           discourse_sync_status: "error",
           discourse_sync_at: new Date().toISOString(),
           discourse_sync_error: errorMessage,
-        }).eq("id", body.questionId);
+        }).eq("id", parsedQuestionId);
+      } catch {
+        console.error(`[${requestId}] Failed to update sync status after error`);
       }
-    } catch {
-      console.error(`[${requestId}] Failed to update sync status after error`);
     }
 
-    return errorResponse('Internal server error', 500, undefined, corsHeaders);
+    return errorResponse('Internal server error', 500, error, corsHeaders);
   }
 });

--- a/supabase/functions/update-discourse-post/index.ts
+++ b/supabase/functions/update-discourse-post/index.ts
@@ -1,10 +1,11 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "jsr:@supabase/supabase-js@2";
 import {
   isValidUuid,
   isServiceRoleToken,
   DISCOURSE_URL,
   getCorsHeaders,
+  errorResponse,
 } from "../_shared/constants.ts";
 import {
   extractTopicId,
@@ -75,7 +76,7 @@ async function getTopicByExternalId(
   }
 }
 
-serve(async (req) => {
+Deno.serve(async (req: Request) => {
   const requestId = crypto.randomUUID().slice(0, 8);
   const corsHeaders = getCorsHeaders(req);
 
@@ -133,11 +134,7 @@ serve(async (req) => {
       console.log(`[${requestId}] Role check - data:`, roleData, "error:", roleError?.message);
 
       if (roleError) {
-        console.error(`[${requestId}] Role check error:`, roleError);
-        return new Response(JSON.stringify({ error: "Failed to check admin role: " + roleError.message }), {
-          status: 500,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        });
+        return errorResponse('Failed to verify access', 500, roleError, corsHeaders);
       }
 
       if (!roleData) {
@@ -417,20 +414,16 @@ serve(async (req) => {
     );
   } catch (error) {
     console.error(`[${requestId}] Update Discourse post error:`, error);
-    const errorMessage =
-      error instanceof Error ? error.message : "Unknown error";
+    const errorMessage = error instanceof Error ? error.message : "Unknown error";
 
     // Try to update the sync status to error
-    // We need to extract questionId from the request if possible
     try {
       const bodyText = await req.clone().text();
       const body = JSON.parse(bodyText);
       if (body.questionId) {
-        console.log(`[${requestId}] Updating sync status to error for question ${body.questionId}`);
         const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
         const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
         const supabase = createClient(supabaseUrl, supabaseKey);
-
         await supabase.from("questions").update({
           discourse_sync_status: "error",
           discourse_sync_at: new Date().toISOString(),
@@ -438,13 +431,9 @@ serve(async (req) => {
         }).eq("id", body.questionId);
       }
     } catch {
-      // Ignore errors updating status - just log the main error
       console.error(`[${requestId}] Failed to update sync status after error`);
     }
 
-    return new Response(JSON.stringify({ error: errorMessage }), {
-      status: 500,
-      headers: { ...corsHeaders, "Content-Type": "application/json" },
-    });
+    return errorResponse('Internal server error', 500, undefined, corsHeaders);
   }
 });

--- a/supabase/functions/verify-discourse-sync/index.ts
+++ b/supabase/functions/verify-discourse-sync/index.ts
@@ -686,6 +686,7 @@ Deno.serve(async (req: Request) => {
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });
   } catch (error) {
-    return errorResponse('Internal server error', 500, error, corsHeaders);
+    console.error(`[${requestId}] Unhandled error:`, error);
+    return errorResponse('Internal server error', 500, undefined, corsHeaders);
   }
 });

--- a/supabase/functions/verify-discourse-sync/index.ts
+++ b/supabase/functions/verify-discourse-sync/index.ts
@@ -1,5 +1,5 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "jsr:@supabase/supabase-js@2";
 import {
   corsHeaders,
   DISCOURSE_URL,
@@ -9,6 +9,7 @@ import {
   getCategorySlug,
   isServiceRoleToken,
   fetchWithBackoff,
+  errorResponse,
 } from "../_shared/constants.ts";
 import {
   extractQuestionIdFromTitle,
@@ -245,7 +246,7 @@ async function verifyTopicDetails(
 // MAIN HANDLER
 // =============================================================================
 
-serve(async (req) => {
+Deno.serve(async (req: Request) => {
   const requestId = crypto.randomUUID().slice(0, 8);
 
   // Handle CORS preflight
@@ -685,12 +686,6 @@ serve(async (req) => {
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });
   } catch (error) {
-    console.error(`[${requestId}] Error:`, error);
-    const errorMessage =
-      error instanceof Error ? error.message : "Unknown error";
-    return new Response(JSON.stringify({ error: errorMessage }), {
-      status: 500,
-      headers: { ...corsHeaders, "Content-Type": "application/json" },
-    });
+    return errorResponse('Internal server error', 500, error, corsHeaders);
   }
 });

--- a/supabase/migrations/20260526000000_drop_decorative_service_role_policies.sql
+++ b/supabase/migrations/20260526000000_drop_decorative_service_role_policies.sql
@@ -1,0 +1,10 @@
+-- M4: Remove decorative service_role RLS policies from alerting tables.
+-- The service_role key bypasses RLS unconditionally, so these policies have
+-- no functional effect. Their presence suggests an intent to use service_role
+-- in a context where RLS applies, which would be a misconfiguration.
+-- Removing them clarifies that access is via RLS bypass, not policy grant.
+
+DROP POLICY IF EXISTS "Service role can view all alert rules" ON public.alert_rules;
+DROP POLICY IF EXISTS "Service role can view all alerts" ON public.alerts;
+DROP POLICY IF EXISTS "Service role can insert alerts" ON public.alerts;
+DROP POLICY IF EXISTS "Service role can update alerts" ON public.alerts;

--- a/supabase/migrations/20260526000001_harden_security_definer_triggers.sql
+++ b/supabase/migrations/20260526000001_harden_security_definer_triggers.sql
@@ -1,0 +1,101 @@
+-- M5: Add auth.uid() defense-in-depth to SECURITY DEFINER triggers.
+-- Both triggers propagate NEW.user_id from the source row into derived tables.
+-- The guard below rejects rows where the session user doesn't match user_id.
+-- The IS NOT NULL check allows service_role (which has null auth.uid()) to pass,
+-- because Edge Functions use service_role to insert into these tables.
+
+CREATE OR REPLACE FUNCTION public.update_question_mastery()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF auth.uid() IS NOT NULL AND auth.uid() <> NEW.user_id THEN
+    RAISE EXCEPTION 'update_question_mastery: user_id mismatch (session=%, row=%)', auth.uid(), NEW.user_id;
+  END IF;
+
+  INSERT INTO public.question_mastery (
+    user_id,
+    question_id,
+    total_attempts,
+    correct_attempts,
+    incorrect_attempts,
+    first_attempt_at,
+    last_attempt_at,
+    updated_at
+  )
+  VALUES (
+    NEW.user_id,
+    NEW.question_id,
+    1,
+    CASE WHEN NEW.is_correct THEN 1 ELSE 0 END,
+    CASE WHEN NEW.is_correct THEN 0 ELSE 1 END,
+    NEW.attempted_at,
+    NEW.attempted_at,
+    now()
+  )
+  ON CONFLICT (user_id, question_id) DO UPDATE SET
+    total_attempts = question_mastery.total_attempts + 1,
+    correct_attempts = question_mastery.correct_attempts + CASE WHEN NEW.is_correct THEN 1 ELSE 0 END,
+    incorrect_attempts = question_mastery.incorrect_attempts + CASE WHEN NEW.is_correct THEN 0 ELSE 1 END,
+    last_attempt_at = NEW.attempted_at,
+    updated_at = now();
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.update_daily_streak()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_yesterday DATE := NEW.activity_date - 1;
+  v_had_activity_yesterday BOOLEAN;
+  v_current_streak INTEGER;
+BEGIN
+  IF auth.uid() IS NOT NULL AND auth.uid() <> NEW.user_id THEN
+    RAISE EXCEPTION 'update_daily_streak: user_id mismatch (session=%, row=%)', auth.uid(), NEW.user_id;
+  END IF;
+
+  -- Only process when activity qualifies for streak
+  IF NOT NEW.qualifies_for_streak THEN
+    RETURN NEW;
+  END IF;
+
+  -- Check if yesterday had qualifying activity
+  SELECT qualifies_for_streak INTO v_had_activity_yesterday
+  FROM public.daily_activity
+  WHERE user_id = NEW.user_id AND activity_date = v_yesterday;
+
+  -- Upsert streak record
+  INSERT INTO public.daily_streaks (user_id, current_streak, longest_streak, last_activity_date)
+  VALUES (
+    NEW.user_id,
+    1,
+    1,
+    NEW.activity_date
+  )
+  ON CONFLICT (user_id) DO UPDATE SET
+    current_streak = CASE
+      WHEN daily_streaks.last_activity_date = NEW.activity_date THEN daily_streaks.current_streak
+      WHEN daily_streaks.last_activity_date = v_yesterday THEN daily_streaks.current_streak + 1
+      ELSE 1
+    END,
+    longest_streak = GREATEST(
+      daily_streaks.longest_streak,
+      CASE
+        WHEN daily_streaks.last_activity_date = NEW.activity_date THEN daily_streaks.current_streak
+        WHEN daily_streaks.last_activity_date = v_yesterday THEN daily_streaks.current_streak + 1
+        ELSE 1
+      END
+    ),
+    last_activity_date = NEW.activity_date,
+    updated_at = now();
+
+  RETURN NEW;
+END;
+$$;

--- a/supabase/migrations/20260526000002_restrict_mapbox_usage_select.sql
+++ b/supabase/migrations/20260526000002_restrict_mapbox_usage_select.sql
@@ -1,0 +1,15 @@
+-- L2: Restrict mapbox_usage SELECT to admin users only.
+-- Previously any authenticated user could read aggregate request counts,
+-- which discloses quota-exhaustion timing. Only admins need this data.
+
+DROP POLICY IF EXISTS "Authenticated users can view mapbox usage" ON public.mapbox_usage;
+
+CREATE POLICY "Admins can view mapbox usage"
+  ON public.mapbox_usage FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.user_roles
+      WHERE user_id = auth.uid() AND role = 'admin'
+    )
+  );

--- a/supabase/migrations/20260526000003_grant_bulk_import_to_authenticated.sql
+++ b/supabase/migrations/20260526000003_grant_bulk_import_to_authenticated.sql
@@ -1,0 +1,5 @@
+-- L3: Grant authenticated users EXECUTE on bulk_import_exam_sessions_safe so the
+-- admin browser UI can call it via supabase.rpc(). The function itself performs
+-- an internal admin role check, so the grant is safe.
+
+GRANT EXECUTE ON FUNCTION public.bulk_import_exam_sessions_safe(JSONB) TO authenticated;

--- a/supabase/migrations/20260526000004_sanitize_display_name_trigger.sql
+++ b/supabase/migrations/20260526000004_sanitize_display_name_trigger.sql
@@ -16,8 +16,17 @@ BEGIN
   v_raw_name := new.raw_user_meta_data ->> 'display_name';
 
   IF v_raw_name IS NOT NULL THEN
-    -- Strip HTML tags and truncate to 100 chars
-    v_safe_name := left(regexp_replace(v_raw_name, '<[^>]*>', '', 'g'), 100);
+    -- Strip literal HTML tags, then decode the four common HTML entities so
+    -- entity-encoded payloads (e.g. &lt;script&gt;) can't survive as raw tags
+    -- in any downstream context that HTML-unescapes before rendering.
+    v_safe_name := regexp_replace(v_raw_name, '<[^>]*>', '', 'g');
+    v_safe_name := replace(replace(replace(replace(v_safe_name,
+      '&lt;',  '<'),
+      '&gt;',  '>'),
+      '&amp;', '&'),
+      '&quot;', '"');
+    -- Strip again after entity decode, then cap at 100 chars
+    v_safe_name := left(regexp_replace(v_safe_name, '<[^>]*>', '', 'g'), 100);
   END IF;
 
   INSERT INTO public.profiles (id, email, display_name)

--- a/supabase/migrations/20260526000004_sanitize_display_name_trigger.sql
+++ b/supabase/migrations/20260526000004_sanitize_display_name_trigger.sql
@@ -1,0 +1,27 @@
+-- L4: Sanitize display_name in handle_new_user trigger.
+-- raw_user_meta_data->>'display_name' is user-controlled at signup.
+-- Cap length to 100 chars and strip HTML tags as defense-in-depth.
+-- React escapes by default, but this prevents raw DB values from being
+-- rendered unsafely in any server-side or non-React context.
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  v_raw_name TEXT;
+  v_safe_name TEXT;
+BEGIN
+  v_raw_name := new.raw_user_meta_data ->> 'display_name';
+
+  IF v_raw_name IS NOT NULL THEN
+    -- Strip HTML tags and truncate to 100 chars
+    v_safe_name := left(regexp_replace(v_raw_name, '<[^>]*>', '', 'g'), 100);
+  END IF;
+
+  INSERT INTO public.profiles (id, email, display_name)
+  VALUES (new.id, new.email, v_safe_name);
+  RETURN new;
+END;
+$$;

--- a/supabase/migrations/20260526000004_sanitize_display_name_trigger.sql
+++ b/supabase/migrations/20260526000004_sanitize_display_name_trigger.sql
@@ -3,6 +3,18 @@
 -- Cap length to 100 chars and strip HTML tags as defense-in-depth.
 -- React escapes by default, but this prevents raw DB values from being
 -- rendered unsafely in any server-side or non-React context.
+--
+-- Sanitization passes (in order):
+--   1. Strip literal HTML tags (<[^>]*>)
+--   2. Strip numeric/hex character references (&#60; &#x3C; etc.)
+--   3. Decode the four common named HTML entities so entity-encoded
+--      payloads (&lt;script&gt;) cannot survive as raw tags after decode
+--   4. Strip literal tags again (catches anything revealed by step 3)
+--   5. Cap at 100 chars
+--
+-- Known limitation: multi-level or mixed encodings (e.g. &amp;lt;) are
+-- not fully resolved. This is intentional — the goal is defense-in-depth
+-- for a display_name field, not a general-purpose HTML sanitizer.
 
 CREATE OR REPLACE FUNCTION public.handle_new_user()
 RETURNS TRIGGER
@@ -16,16 +28,18 @@ BEGIN
   v_raw_name := new.raw_user_meta_data ->> 'display_name';
 
   IF v_raw_name IS NOT NULL THEN
-    -- Strip literal HTML tags, then decode the four common HTML entities so
-    -- entity-encoded payloads (e.g. &lt;script&gt;) can't survive as raw tags
-    -- in any downstream context that HTML-unescapes before rendering.
+    -- Pass 1: strip literal HTML tags
     v_safe_name := regexp_replace(v_raw_name, '<[^>]*>', '', 'g');
+    -- Pass 2: strip numeric/hex character references (&#60; &#x3C; &#X3c; etc.)
+    v_safe_name := regexp_replace(v_safe_name, '&#[xX]?[0-9a-fA-F]+;', '', 'g');
+    -- Pass 3: decode the four common named HTML entities so encoded payloads
+    -- (&lt;script&gt;) can't survive as raw tags after decode
     v_safe_name := replace(replace(replace(replace(v_safe_name,
       '&lt;',  '<'),
       '&gt;',  '>'),
       '&amp;', '&'),
       '&quot;', '"');
-    -- Strip again after entity decode, then cap at 100 chars
+    -- Pass 4: strip any tags revealed by entity decode, then cap at 100 chars
     v_safe_name := left(regexp_replace(v_safe_name, '<[^>]*>', '', 'g'), 100);
   END IF;
 


### PR DESCRIPTION
## Summary

Closes out all remaining open security issues from the 2026-05-22 security review (#213). Skipped M2 (rate limiting — requires infrastructure tables) and M8 (extract admin writes to hooks — large refactor warranting a separate PR).

**Edge Functions (M1, M6, M7)**
- Added `errorResponse()` helper to `_shared/constants.ts` — logs full error server-side, returns only a generic message to callers. Replaces raw `error.message` returns in catch blocks across 6 functions (closes #221)
- Migrated 7 Edge Functions from `deno.land/std@0.168.0 serve()` + `esm.sh` to `Deno.serve()` + `jsr:@supabase/supabase-js@2` (closes #226)
- Added `requireAdmin()` helper using `maybeSingle + eq('role','admin')` pattern; replaced the subtly wrong `.single()` check in `sync-discourse-topics` (closes #227)

**Database migrations (M4, M5, L2, L3, L4)**
- Drop decorative `service_role` RLS policies from alerting tables — no functional effect since service_role bypasses RLS unconditionally (closes #224)
- Add `auth.uid()` mismatch guard to `update_question_mastery` and `update_daily_streak` SECURITY DEFINER triggers; service_role (null `auth.uid()`) still passes (closes #225)
- Restrict `mapbox_usage` SELECT to admins only (closes L2 from #229)
- Grant `authenticated` EXECUTE on `bulk_import_exam_sessions_safe` so admin UI can call it via `supabase.rpc()` — in-function admin check is the real gate (closes L3 from #229)
- Sanitize `raw_user_meta_data->>'display_name'` in `handle_new_user` trigger: strip HTML tags, cap at 100 chars (closes L4 from #229)

**Client-side (M3, L1, L5)**
- Replace `user?.id || ''` fallback with explicit null guards in 7 admin components so missing sessions surface immediately (closes #223)
- Remove hardcoded demo `service_role` JWT from `scripts/migrate-topic-content.ts`; hard-exit if no key env var is set (closes L1 from #229)
- Add `VITE_TRUSTED_OAUTH_CLIENT_IDS` allowlist guard to `useOAuthConsent` — auto-approve only fires for explicitly trusted OAuth clients (closes L5 from #229)

## Deployment notes

- 5 new migrations require `supabase db push` (or auto-applied on Vercel preview)
- `VITE_TRUSTED_OAUTH_CLIENT_IDS`: add this env var with the Discourse OAuth `client_id` to restore auto-approve for the forum SSO flow
- All 3313 tests pass, lint clean

## Test plan

- [ ] Practice test and random practice flows unaffected (trigger change)
- [ ] Admin glossary/topics/lessons CRUD still works after null guard changes
- [ ] `sync-discourse-topics` admin check still rejects non-admins
- [ ] Edge Function 500 responses no longer echo internal error details
- [ ] OAuth consent flow: auto-approve only with `VITE_TRUSTED_OAUTH_CLIENT_IDS` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)