### PR TITLE
fix: remove orphaned seed-questions function config (unblocks Supabase deploy)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,7 +175,7 @@ All colors are HSL format defined as CSS custom properties. The design system su
 **Row Level Security (RLS)**: All user data is protected. Users can only access their own attempts/results/bookmarks.
 
 **Edge Functions** (`supabase/functions/`):
-Key functions: `calculate-readiness` (server-side scoring), `track-user-signup`, `question-opengraph` (OG image generation), `sync-discourse-topics` / `discourse-webhook` / `manage-question-links` / `update-discourse-post` (Discourse forum integration), `system-monitor`, `seed-questions`.
+Key functions: `calculate-readiness` (server-side scoring), `track-user-signup`, `question-opengraph` (OG image generation), `sync-discourse-topics` / `discourse-webhook` / `manage-question-links` / `update-discourse-post` (Discourse forum integration), `system-monitor`.
 - Local dev: `npm run supabase:functions` (auto-started by `npm run dev:full`)
 - Tests run via Deno: `npm run supabase:functions:test`
 - Deploy: `supabase functions deploy <name>`

--- a/LOCAL_DEVELOPMENT.md
+++ b/LOCAL_DEVELOPMENT.md
@@ -301,7 +301,6 @@ curl -i --location --request POST 'http://localhost:54321/functions/v1/function-
 - `delete-user` - Delete user account
 - `geocode-addresses` - Geocode exam session addresses
 - `manage-question-links` - Manage learning resource links
-- `seed-questions` - Seed initial questions
 
 ## Database Access
 

--- a/docs/SUPABASE_MIGRATION.md
+++ b/docs/SUPABASE_MIGRATION.md
@@ -533,7 +533,6 @@ Copy the edge functions from `supabase/functions/` to your new Supabase project:
 1. **delete-user** - Handles user account deletion
 2. **geocode-addresses** - Geocodes exam session addresses
 3. **manage-question-links** - Manages question learning resource links
-4. **seed-questions** - Seeds initial question data
 
 Deploy using the Supabase CLI:
 
@@ -541,7 +540,6 @@ Deploy using the Supabase CLI:
 supabase functions deploy delete-user
 supabase functions deploy geocode-addresses
 supabase functions deploy manage-question-links
-supabase functions deploy seed-questions
 ```
 
 ## Step 9: Update Environment Variables

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -34,9 +34,6 @@ verify_jwt = false
 [functions.question-opengraph]
 verify_jwt = false
 
-[functions.seed-questions]
-verify_jwt = false
-
 [functions.sync-discourse-topics]
 verify_jwt = false
 


### PR DESCRIPTION
## Problem
Every branch's **Supabase Preview** deploy has been failing with:

```
Error: entrypoint path does not exist (supabase/functions/seed-questions/index.ts)
failed to bundle function: exit status 1
```

## Root cause
The `seed-questions` Edge Function was **deleted** in the C1/#214 security fix (`d0f8d07` — it performed unauthenticated `service_role` writes; local seeding is handled by `supabase/seed.sql`). But its `[functions.seed-questions]` stanza was left behind in `supabase/config.toml`. The deploy step reads `config.toml`, tries to bundle a function whose `index.ts` no longer exists, and fails — which is why "Supabase Preview" has been red on every recent PR (#233, #234, #235, …) regardless of the PR's contents.

## Fix
- Remove the orphaned `[functions.seed-questions]` stanza from `supabase/config.toml`. Verified `config.toml` still parses and **all 11 remaining stanzas map to a real `index.ts`**.
- Purge the now-dead `seed-questions` references from `CLAUDE.md`, `docs/SUPABASE_MIGRATION.md`, and `LOCAL_DEVELOPMENT.md`.

No function code or runtime behavior changes — this is config/doc cleanup that restores the deploy.

## Note
This should land first; it unblocks Supabase Preview for all other open PRs (#236, #237). (Those docs also list `delete-user` / `geocode-addresses`, which likewise no longer exist — left as separate pre-existing doc rot, out of scope here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)