### PR TITLE
docs: sync README and CONTRIBUTING with current codebase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Thank you for your interest in contributing to the Open Ham Prep application! Th
 
 ### Prerequisites
 
-1. Node.js 18+ installed
+1. Node.js 20+ installed
 2. Git configured with your GitHub account
 3. Familiarity with React, TypeScript, and Tailwind CSS
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,16 @@ A modern web application for studying US Amateur Radio license exams. Open sourc
 
 - **Practice Tests** - Simulated exam experience with optional timer
 - **Random Practice** - Study questions with instant feedback
-- **Study by Topics** - Focus on specific subelements with learning resources
+- **Study by Topics** - Focus on specific subelements with topic mastery quizzes
+- **Lessons** - Curated, guided study units
+- **ARRL Chapters** - Practice scoped to ARRL study-book chapters
 - **Weak Questions** - Review questions you've missed
 - **Glossary & Flashcards** - Learn key terms with spaced repetition
+- **Exam Sessions** - Find upcoming in-person VE exam sessions near you
+- **Ham Radio Tools** - Curated gallery of external ham radio tools
 - **Progress Tracking** - Dashboard with test readiness, streaks, and goals
 - **Bookmarks** - Save questions with personal notes
+- **Guest Mode + PWA** - Study without an account; installable as a Progressive Web App
 
 Supports all three license classes: Technician, General, and Extra.
 
@@ -45,7 +50,7 @@ See [LOCAL_DEVELOPMENT.md](LOCAL_DEVELOPMENT.md) for details.
 
 **Backend:** Supabase (PostgreSQL, Auth, Edge Functions, Realtime)
 
-**Tooling:** Vitest, ESLint, Pendo (analytics), Sentry (error tracking)
+**Tooling:** Vitest, ESLint, Amplitude & Pendo (product analytics), Sentry (error tracking), Vercel Analytics & Speed Insights
 
 ## Architecture
 
@@ -58,11 +63,14 @@ See [LOCAL_DEVELOPMENT.md](LOCAL_DEVELOPMENT.md) for details.
 
 ### Context Providers
 
-The app wraps components in this provider order (see `App.tsx`):
+The app wraps components in this provider order, outermost → innermost (see `App.tsx`):
 1. ThemeProvider (next-themes)
-2. QueryClientProvider (TanStack Query)
-3. AuthProvider (Supabase auth)
-4. AppNavigationProvider (license filter)
+2. AccessibilityProvider (a11y prefs)
+3. QueryClientProvider (TanStack Query)
+4. AuthProvider (Supabase auth — gates user-scoped queries)
+5. PendoProvider + AmplitudeProvider (product analytics)
+6. AppNavigationProvider (global license filter)
+7. TooltipProvider (Radix)
 
 ### Project Structure
 
@@ -74,8 +82,11 @@ src/
 │   └── *.tsx        # Feature components
 ├── hooks/           # Custom React hooks
 ├── pages/           # Route page components
+├── services/        # Service layer + centralized query keys
 ├── lib/             # Utilities
 ├── integrations/    # Supabase client (auto-generated)
+├── assets/          # Static assets
+├── test/            # Test setup and helpers
 └── types/           # TypeScript types
 ```
 


### PR DESCRIPTION
## Description
Updates the README and CONTRIBUTING docs to match the current state of the codebase. Doc-only changes — no code touched.

## Changes Made
**README.md**
- Features: add Lessons, ARRL Chapters, Exam Sessions, Ham Radio Tools, and Guest Mode + PWA; clarify that Study by Topics includes topic mastery quizzes
- Tech stack: list Amplitude & Pendo, Sentry, and Vercel Analytics & Speed Insights (all wired into `App.tsx`/`main.tsx`)
- Context Providers: update the 4-item list to the real 8-provider order in `App.tsx` (adds AccessibilityProvider, Pendo/Amplitude, TooltipProvider)
- Project Structure: add the `services/`, `assets/`, and `test/` directories

**CONTRIBUTING.md**
- Bump Node requirement from 18+ to 20+ to match the repo and other docs

## Testing Done
- [x] Verified each claim against `App.tsx`, `package.json`, `src/hooks/`, and `src/services/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)