### PR TITLE
Collapse topic sidebar horizontally to give content more width

### DIFF
--- a/src/components/TopicDetailPage.test.tsx
+++ b/src/components/TopicDetailPage.test.tsx
@@ -382,5 +382,21 @@ describe('TopicDetailPage', () => {
       const grid = container.querySelector('div.grid') as HTMLElement;
       expect(grid.className).toContain('lg:grid-cols-[1fr_auto]');
     });
+
+    it('should render the sidebar when there are resources but no questions', () => {
+      // Exercises the `resources.length > 0` branch of hasSidebarContent
+      mockTopicData = { ...mockTopic }; // mockTopic has one resource
+      mockTopicQuestions = [];
+      const { container } = renderComponent();
+
+      expect(
+        screen.getByRole('button', { name: 'Show Questions & Resources' })
+      ).toBeInTheDocument();
+      expect(screen.getByTestId('resource-panel')).toBeInTheDocument();
+
+      // Grid reserves the collapsed sidebar column
+      const grid = container.querySelector('div.grid') as HTMLElement;
+      expect(grid.className).toContain('lg:grid-cols-[1fr_auto]');
+    });
   });
 });

--- a/src/components/TopicDetailPage.test.tsx
+++ b/src/components/TopicDetailPage.test.tsx
@@ -67,6 +67,7 @@ const mockTopic: Topic = {
 let mockTopicData: Topic | null = mockTopic;
 let mockTopicLoading = false;
 let mockTopicError: Error | null = null;
+let mockTopicQuestions: Array<{ id: string }> = [];
 
 vi.mock('@/hooks/useTopics', () => ({
   useTopic: () => ({
@@ -75,7 +76,7 @@ vi.mock('@/hooks/useTopics', () => ({
     error: mockTopicError,
   }),
   useTopicQuestions: () => ({
-    data: [],
+    data: mockTopicQuestions,
     isLoading: false,
   }),
   useTopicCompleted: () => false,
@@ -124,6 +125,7 @@ describe('TopicDetailPage', () => {
     mockTopicData = mockTopic;
     mockTopicLoading = false;
     mockTopicError = null;
+    mockTopicQuestions = [];
   });
 
   describe('Loading State', () => {
@@ -257,6 +259,128 @@ describe('TopicDetailPage', () => {
       renderComponent();
 
       expect(screen.queryByText('Introduction to amateur radio')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Collapsible sidebar', () => {
+    const getGrid = (container: HTMLElement) =>
+      container.querySelector('div.grid') as HTMLElement;
+
+    it('should be collapsed by default, showing the rail and narrowing the grid', () => {
+      const { container } = renderComponent();
+
+      // Rail (expand control) is present when collapsed
+      const rail = screen.getByRole('button', { name: 'Show Questions & Resources' });
+      expect(rail).toBeInTheDocument();
+      expect(rail).toHaveAttribute('aria-expanded', 'false');
+
+      // Grid uses the collapsed (auto) template, not the 280px one
+      expect(getGrid(container).className).toContain('lg:grid-cols-[1fr_auto]');
+      expect(getGrid(container).className).not.toContain('lg:grid-cols-[1fr_280px]');
+    });
+
+    it('should expand to the wide sidebar when the rail is clicked', () => {
+      const { container } = renderComponent();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Show Questions & Resources' }));
+
+      // Rail is gone; hide control is now the expanded toggle
+      expect(
+        screen.queryByRole('button', { name: 'Show Questions & Resources' })
+      ).not.toBeInTheDocument();
+      const hide = screen.getByRole('button', { name: 'Hide Questions & Resources' });
+      expect(hide).toHaveAttribute('aria-expanded', 'true');
+
+      // Grid switches to the fixed 280px template
+      expect(getGrid(container).className).toContain('lg:grid-cols-[1fr_280px]');
+    });
+
+    it('should collapse again when the hide control is clicked', () => {
+      const { container } = renderComponent();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Show Questions & Resources' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Hide Questions & Resources' }));
+
+      expect(
+        screen.getByRole('button', { name: 'Show Questions & Resources' })
+      ).toBeInTheDocument();
+      expect(getGrid(container).className).toContain('lg:grid-cols-[1fr_auto]');
+    });
+
+    it('should point both toggles at the panel region via aria-controls', () => {
+      renderComponent();
+
+      const rail = screen.getByRole('button', { name: 'Show Questions & Resources' });
+      expect(rail).toHaveAttribute('aria-controls', 'topic-sidebar-panels');
+      expect(document.getElementById('topic-sidebar-panels')).toBeInTheDocument();
+    });
+
+    it('should label the sidebar landmark', () => {
+      renderComponent();
+      expect(
+        screen.getByRole('complementary', { name: 'Questions and resources' })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Sidebar focus management', () => {
+    it('should move focus to the hide control when expanding', () => {
+      renderComponent();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Show Questions & Resources' }));
+
+      expect(screen.getByRole('button', { name: 'Hide Questions & Resources' })).toHaveFocus();
+    });
+
+    it('should move focus back to the rail when collapsing', () => {
+      renderComponent();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Show Questions & Resources' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Hide Questions & Resources' }));
+
+      expect(screen.getByRole('button', { name: 'Show Questions & Resources' })).toHaveFocus();
+    });
+
+    it('should not steal focus on the initial collapsed render', () => {
+      renderComponent();
+
+      // Nothing should be auto-focused before the user interacts
+      expect(document.body).toHaveFocus();
+    });
+  });
+
+  describe('Empty sidebar', () => {
+    it('should not render the sidebar or rail when there are no questions and no resources', () => {
+      mockTopicData = { ...mockTopic, resources: [] };
+      mockTopicQuestions = [];
+      const { container } = renderComponent();
+
+      expect(
+        screen.queryByRole('button', { name: 'Show Questions & Resources' })
+      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId('questions-panel')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('resource-panel')).not.toBeInTheDocument();
+
+      // Grid reserves no sidebar column
+      const grid = container.querySelector('div.grid') as HTMLElement;
+      expect(grid.className).not.toContain('lg:grid-cols-[1fr_280px]');
+      expect(grid.className).not.toContain('lg:grid-cols-[1fr_auto]');
+    });
+
+    it('should render the sidebar when there are questions but no resources', () => {
+      // Exercises the `questionCount > 0` branch of hasSidebarContent
+      mockTopicData = { ...mockTopic, resources: [] };
+      mockTopicQuestions = [{ id: 'T1A01' }];
+      const { container } = renderComponent();
+
+      expect(
+        screen.getByRole('button', { name: 'Show Questions & Resources' })
+      ).toBeInTheDocument();
+      expect(screen.getByTestId('questions-panel')).toBeInTheDocument();
+
+      // Grid reserves the collapsed sidebar column
+      const grid = container.querySelector('div.grid') as HTMLElement;
+      expect(grid.className).toContain('lg:grid-cols-[1fr_auto]');
     });
   });
 });

--- a/src/components/TopicDetailPage.test.tsx
+++ b/src/components/TopicDetailPage.test.tsx
@@ -128,6 +128,8 @@ describe('TopicDetailPage', () => {
     mockTopicQuestions = [];
   });
 
+  const getGrid = () => screen.getByTestId('topic-layout-grid');
+
   describe('Loading State', () => {
     it('should show loading skeleton when topic is loading', () => {
       mockTopicLoading = true;
@@ -263,11 +265,8 @@ describe('TopicDetailPage', () => {
   });
 
   describe('Collapsible sidebar', () => {
-    const getGrid = (container: HTMLElement) =>
-      container.querySelector('div.grid') as HTMLElement;
-
     it('should be collapsed by default, showing the rail and narrowing the grid', () => {
-      const { container } = renderComponent();
+      renderComponent();
 
       // Rail (expand control) is present when collapsed
       const rail = screen.getByRole('button', { name: 'Show Questions & Resources' });
@@ -275,12 +274,12 @@ describe('TopicDetailPage', () => {
       expect(rail).toHaveAttribute('aria-expanded', 'false');
 
       // Grid uses the collapsed (auto) template, not the 280px one
-      expect(getGrid(container).className).toContain('lg:grid-cols-[1fr_auto]');
-      expect(getGrid(container).className).not.toContain('lg:grid-cols-[1fr_280px]');
+      expect(getGrid().className).toContain('lg:grid-cols-[1fr_auto]');
+      expect(getGrid().className).not.toContain('lg:grid-cols-[1fr_280px]');
     });
 
     it('should expand to the wide sidebar when the rail is clicked', () => {
-      const { container } = renderComponent();
+      renderComponent();
 
       fireEvent.click(screen.getByRole('button', { name: 'Show Questions & Resources' }));
 
@@ -292,11 +291,11 @@ describe('TopicDetailPage', () => {
       expect(hide).toHaveAttribute('aria-expanded', 'true');
 
       // Grid switches to the fixed 280px template
-      expect(getGrid(container).className).toContain('lg:grid-cols-[1fr_280px]');
+      expect(getGrid().className).toContain('lg:grid-cols-[1fr_280px]');
     });
 
     it('should collapse again when the hide control is clicked', () => {
-      const { container } = renderComponent();
+      renderComponent();
 
       fireEvent.click(screen.getByRole('button', { name: 'Show Questions & Resources' }));
       fireEvent.click(screen.getByRole('button', { name: 'Hide Questions & Resources' }));
@@ -304,7 +303,7 @@ describe('TopicDetailPage', () => {
       expect(
         screen.getByRole('button', { name: 'Show Questions & Resources' })
       ).toBeInTheDocument();
-      expect(getGrid(container).className).toContain('lg:grid-cols-[1fr_auto]');
+      expect(getGrid().className).toContain('lg:grid-cols-[1fr_auto]');
     });
 
     it('should point both toggles at the panel region via aria-controls', () => {
@@ -353,7 +352,7 @@ describe('TopicDetailPage', () => {
     it('should not render the sidebar or rail when there are no questions and no resources', () => {
       mockTopicData = { ...mockTopic, resources: [] };
       mockTopicQuestions = [];
-      const { container } = renderComponent();
+      renderComponent();
 
       expect(
         screen.queryByRole('button', { name: 'Show Questions & Resources' })
@@ -362,16 +361,15 @@ describe('TopicDetailPage', () => {
       expect(screen.queryByTestId('resource-panel')).not.toBeInTheDocument();
 
       // Grid reserves no sidebar column
-      const grid = container.querySelector('div.grid') as HTMLElement;
-      expect(grid.className).not.toContain('lg:grid-cols-[1fr_280px]');
-      expect(grid.className).not.toContain('lg:grid-cols-[1fr_auto]');
+      expect(getGrid().className).not.toContain('lg:grid-cols-[1fr_280px]');
+      expect(getGrid().className).not.toContain('lg:grid-cols-[1fr_auto]');
     });
 
     it('should render the sidebar when there are questions but no resources', () => {
       // Exercises the `questionCount > 0` branch of hasSidebarContent
       mockTopicData = { ...mockTopic, resources: [] };
       mockTopicQuestions = [{ id: 'T1A01' }];
-      const { container } = renderComponent();
+      renderComponent();
 
       expect(
         screen.getByRole('button', { name: 'Show Questions & Resources' })
@@ -379,15 +377,14 @@ describe('TopicDetailPage', () => {
       expect(screen.getByTestId('questions-panel')).toBeInTheDocument();
 
       // Grid reserves the collapsed sidebar column
-      const grid = container.querySelector('div.grid') as HTMLElement;
-      expect(grid.className).toContain('lg:grid-cols-[1fr_auto]');
+      expect(getGrid().className).toContain('lg:grid-cols-[1fr_auto]');
     });
 
     it('should render the sidebar when there are resources but no questions', () => {
       // Exercises the `resources.length > 0` branch of hasSidebarContent
       mockTopicData = { ...mockTopic }; // mockTopic has one resource
       mockTopicQuestions = [];
-      const { container } = renderComponent();
+      renderComponent();
 
       expect(
         screen.getByRole('button', { name: 'Show Questions & Resources' })
@@ -395,8 +392,38 @@ describe('TopicDetailPage', () => {
       expect(screen.getByTestId('resource-panel')).toBeInTheDocument();
 
       // Grid reserves the collapsed sidebar column
-      const grid = container.querySelector('div.grid') as HTMLElement;
-      expect(grid.className).toContain('lg:grid-cols-[1fr_auto]');
+      expect(getGrid().className).toContain('lg:grid-cols-[1fr_auto]');
+    });
+  });
+
+  describe('Topic navigation', () => {
+    it('should collapse the sidebar again when navigating to a different topic', () => {
+      const { rerender } = renderComponent('topic-a');
+
+      // Expand on the first topic
+      fireEvent.click(screen.getByRole('button', { name: 'Show Questions & Resources' }));
+      expect(
+        screen.queryByRole('button', { name: 'Show Questions & Resources' })
+      ).not.toBeInTheDocument();
+
+      // Navigate to a different topic (component reconciles in place, no remount)
+      rerender(
+        <BrowserRouter>
+          <QueryClientProvider client={queryClient}>
+            <AppNavigationProvider>
+              <TopicDetailPage slug="topic-b" onBack={mockOnBack} />
+            </AppNavigationProvider>
+          </QueryClientProvider>
+        </BrowserRouter>
+      );
+
+      // Sidebar is collapsed again, and focus was not yanked to the rail
+      expect(
+        screen.getByRole('button', { name: 'Show Questions & Resources' })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Show Questions & Resources' })
+      ).not.toHaveFocus();
     });
   });
 });

--- a/src/components/TopicDetailPage.tsx
+++ b/src/components/TopicDetailPage.tsx
@@ -58,6 +58,15 @@ export function TopicDetailPage({ slug, onBack }: TopicDetailPageProps) {
     }
   }, [sidebarOpen]);
 
+  // Collapse the sidebar when navigating to a different topic so every topic
+  // opens at its default. prevSidebarOpenRef is synced here so the focus effect
+  // above treats this as "no change" and doesn't yank focus to the rail on
+  // navigation (the component reconciles in place rather than remounting).
+  useEffect(() => {
+    setSidebarOpen(false);
+    prevSidebarOpenRef.current = false;
+  }, [slug]);
+
   // Track topic view in Amplitude when slug changes
   useEffect(() => {
     trackTopicViewed(slug);
@@ -214,6 +223,7 @@ export function TopicDetailPage({ slug, onBack }: TopicDetailPageProps) {
       {/* Main content area - two column layout */}
       <div className="max-w-7xl mx-auto px-4 md:px-8 py-8 md:py-12">
         <div
+          data-testid="topic-layout-grid"
           className={cn(
             "grid grid-cols-1 gap-8",
             !hasSidebarContent
@@ -267,6 +277,10 @@ export function TopicDetailPage({ slug, onBack }: TopicDetailPageProps) {
               transition={{ delay: 0.2 }}
               aria-label="Questions and resources"
             >
+              {/* On mobile the panels are always visible (stacked below the
+                  content); the rail and Hide controls are desktop-only
+                  (hidden lg:flex), so this collapse behavior is intentionally
+                  asymmetric across breakpoints. */}
               {/* Desktop collapsed rail - click to reopen the sidebar */}
               {!sidebarOpen && (
                 <button

--- a/src/components/TopicDetailPage.tsx
+++ b/src/components/TopicDetailPage.tsx
@@ -17,12 +17,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { ArrowLeft, FileText, PlayCircle, Loader2 } from "lucide-react";
-import { useState, useEffect } from "react";
+import { ArrowLeft, FileText, PlayCircle, Loader2, PanelLeftOpen, ChevronRight } from "lucide-react";
+import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { trackTopicViewed, trackQuizStarted } from "@/lib/amplitude";
 import { motion } from "framer-motion";
 import { PageContainer } from "@/components/ui/page-container";
+import { cn } from "@/lib/utils";
 import { TOPIC_QUIZ_PASSING_THRESHOLD } from "@/types/navigation";
 
 interface TopicDetailPageProps {
@@ -37,6 +38,34 @@ export function TopicDetailPage({ slug, onBack }: TopicDetailPageProps) {
   const { data: topic, isLoading: topicLoading, error: topicError } = useTopic(slug);
   const { data: topicQuestions } = useTopicQuestions(topic?.id);
   const [isQuizOpen, setIsQuizOpen] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const railButtonRef = useRef<HTMLButtonElement>(null);
+  const hideButtonRef = useRef<HTMLButtonElement>(null);
+  // Tracks whether the user has toggled the sidebar, so we only move focus on
+  // user-initiated changes (not on the initial collapsed-by-default mount).
+  const sidebarInteractedRef = useRef(false);
+
+  // When the sidebar is toggled, move focus to the control that is now visible
+  // so keyboard / screen-reader users don't lose their place when the button
+  // they clicked becomes hidden.
+  useEffect(() => {
+    if (!sidebarInteractedRef.current) return;
+    if (sidebarOpen) {
+      hideButtonRef.current?.focus();
+    } else {
+      railButtonRef.current?.focus();
+    }
+  }, [sidebarOpen]);
+
+  const openSidebar = () => {
+    sidebarInteractedRef.current = true;
+    setSidebarOpen(true);
+  };
+
+  const closeSidebar = () => {
+    sidebarInteractedRef.current = true;
+    setSidebarOpen(false);
+  };
 
   // Track topic view in Amplitude when slug changes
   useEffect(() => {
@@ -139,6 +168,9 @@ export function TopicDetailPage({ slug, onBack }: TopicDetailPageProps) {
   // Default content if no markdown is available
   const displayContent = topic.content || `# ${topic.title}\n\n${topic.description || "Content coming soon..."}\n\nThis topic is still being developed. Check back later for the full article.`;
 
+  // Only reserve the sidebar column when there's actually something to show in it
+  const hasSidebarContent = questionCount > 0 || (topic.resources?.length ?? 0) > 0;
+
   return (
     <div className="flex-1 overflow-y-auto">
       {/* Header */}
@@ -190,7 +222,16 @@ export function TopicDetailPage({ slug, onBack }: TopicDetailPageProps) {
 
       {/* Main content area - two column layout */}
       <div className="max-w-7xl mx-auto px-4 md:px-8 py-8 md:py-12">
-        <div className="grid grid-cols-1 lg:grid-cols-[1fr_280px] gap-8">
+        <div
+          className={cn(
+            "grid grid-cols-1 gap-8",
+            !hasSidebarContent
+              ? ""
+              : sidebarOpen
+                ? "lg:grid-cols-[1fr_280px]"
+                : "lg:grid-cols-[1fr_auto]"
+          )}
+        >
           {/* Main content */}
           <motion.main
             initial={{ opacity: 0, y: 20 }}
@@ -228,19 +269,57 @@ export function TopicDetailPage({ slug, onBack }: TopicDetailPageProps) {
           </motion.main>
 
           {/* Right sidebar - Questions and Resources */}
-          <motion.aside
-            initial={{ opacity: 0, x: 20 }}
-            animate={{ opacity: 1, x: 0 }}
-            transition={{ delay: 0.2 }}
-          >
-            <div className="sticky top-4 space-y-0">
-              <TopicQuestionsPanel
-                topicId={topic.id}
-                onQuestionClick={handleQuestionClick}
-              />
-              <TopicResourcePanel resources={topic.resources || []} />
-            </div>
-          </motion.aside>
+          {hasSidebarContent && (
+            <motion.aside
+              initial={{ opacity: 0, x: 20 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ delay: 0.2 }}
+              aria-label="Questions and resources"
+            >
+              {/* Desktop collapsed rail - click to reopen the sidebar */}
+              {!sidebarOpen && (
+                <button
+                  ref={railButtonRef}
+                  onClick={openSidebar}
+                  aria-label="Show Questions & Resources"
+                  aria-expanded={false}
+                  aria-controls="topic-sidebar-panels"
+                  className="hidden lg:flex sticky top-4 w-11 flex-col items-center gap-3 py-3 rounded-lg border border-border bg-card text-muted-foreground hover:text-primary hover:bg-secondary/30 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                >
+                  <PanelLeftOpen className="w-4 h-4" aria-hidden="true" />
+                  <span className="text-xs font-medium tracking-wide [writing-mode:vertical-rl] rotate-180">
+                    Questions &amp; Resources
+                  </span>
+                </button>
+              )}
+
+              {/* Panels - always shown on mobile; on desktop only when open */}
+              <div
+                id="topic-sidebar-panels"
+                className={cn(sidebarOpen ? "lg:block" : "lg:hidden")}
+              >
+                <div className="sticky top-4 space-y-0">
+                  {/* Desktop-only collapse toggle */}
+                  <button
+                    ref={hideButtonRef}
+                    onClick={closeSidebar}
+                    aria-label="Hide Questions & Resources"
+                    aria-expanded={true}
+                    aria-controls="topic-sidebar-panels"
+                    className="hidden lg:flex items-center gap-1 ml-auto mb-2 text-xs font-medium text-muted-foreground hover:text-primary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded"
+                  >
+                    Hide
+                    <ChevronRight className="w-4 h-4" aria-hidden="true" />
+                  </button>
+                  <TopicQuestionsPanel
+                    topicId={topic.id}
+                    onQuestionClick={handleQuestionClick}
+                  />
+                  <TopicResourcePanel resources={topic.resources || []} />
+                </div>
+              </div>
+            </motion.aside>
+          )}
         </div>
       </div>
 

--- a/src/components/TopicDetailPage.tsx
+++ b/src/components/TopicDetailPage.tsx
@@ -17,7 +17,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { ArrowLeft, FileText, PlayCircle, Loader2, PanelLeftOpen, ChevronRight } from "lucide-react";
+import { ArrowLeft, FileText, PlayCircle, Loader2, PanelLeftOpen, PanelRightClose } from "lucide-react";
 import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { trackTopicViewed, trackQuizStarted } from "@/lib/amplitude";
@@ -41,31 +41,22 @@ export function TopicDetailPage({ slug, onBack }: TopicDetailPageProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const railButtonRef = useRef<HTMLButtonElement>(null);
   const hideButtonRef = useRef<HTMLButtonElement>(null);
-  // Tracks whether the user has toggled the sidebar, so we only move focus on
-  // user-initiated changes (not on the initial collapsed-by-default mount).
-  const sidebarInteractedRef = useRef(false);
+  // Previous value of sidebarOpen, so the focus effect fires only on an actual
+  // change and never on the initial render — regardless of the default value.
+  const prevSidebarOpenRef = useRef(sidebarOpen);
 
   // When the sidebar is toggled, move focus to the control that is now visible
   // so keyboard / screen-reader users don't lose their place when the button
   // they clicked becomes hidden.
   useEffect(() => {
-    if (!sidebarInteractedRef.current) return;
+    if (prevSidebarOpenRef.current === sidebarOpen) return;
+    prevSidebarOpenRef.current = sidebarOpen;
     if (sidebarOpen) {
       hideButtonRef.current?.focus();
     } else {
       railButtonRef.current?.focus();
     }
   }, [sidebarOpen]);
-
-  const openSidebar = () => {
-    sidebarInteractedRef.current = true;
-    setSidebarOpen(true);
-  };
-
-  const closeSidebar = () => {
-    sidebarInteractedRef.current = true;
-    setSidebarOpen(false);
-  };
 
   // Track topic view in Amplitude when slug changes
   useEffect(() => {
@@ -280,9 +271,9 @@ export function TopicDetailPage({ slug, onBack }: TopicDetailPageProps) {
               {!sidebarOpen && (
                 <button
                   ref={railButtonRef}
-                  onClick={openSidebar}
+                  onClick={() => setSidebarOpen(true)}
                   aria-label="Show Questions & Resources"
-                  aria-expanded={false}
+                  aria-expanded={sidebarOpen}
                   aria-controls="topic-sidebar-panels"
                   className="hidden lg:flex sticky top-4 w-11 flex-col items-center gap-3 py-3 rounded-lg border border-border bg-card text-muted-foreground hover:text-primary hover:bg-secondary/30 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 >
@@ -302,14 +293,14 @@ export function TopicDetailPage({ slug, onBack }: TopicDetailPageProps) {
                   {/* Desktop-only collapse toggle */}
                   <button
                     ref={hideButtonRef}
-                    onClick={closeSidebar}
+                    onClick={() => setSidebarOpen(false)}
                     aria-label="Hide Questions & Resources"
-                    aria-expanded={true}
+                    aria-expanded={sidebarOpen}
                     aria-controls="topic-sidebar-panels"
                     className="hidden lg:flex items-center gap-1 ml-auto mb-2 text-xs font-medium text-muted-foreground hover:text-primary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded"
                   >
                     Hide
-                    <ChevronRight className="w-4 h-4" aria-hidden="true" />
+                    <PanelRightClose className="w-4 h-4" aria-hidden="true" />
                   </button>
                   <TopicQuestionsPanel
                     topicId={topic.id}


### PR DESCRIPTION
## Summary

Topic detail pages held a fixed **280px right column** for the Related Questions and Resources panels, which only expanded *vertically* via `Collapsible`. The column reserved horizontal space even when collapsed — and even for topics with no questions/resources — leaving the article content cramped.

This replaces it with a **horizontally-collapsing sidebar** (desktop), so the topic content gets as much width as possible.

Closes #242.

## Changes

- **Collapsed by default** to a thin ~44px vertical rail; clicking it slides the panels back in inline (no overlay). Content widens to fill the freed space via a conditional grid template — `lg:grid-cols-[1fr_auto]` collapsed, `lg:grid-cols-[1fr_280px]` expanded.
- **Sidebar only renders when there's content** (`questionCount > 0 || resources.length > 0`), so empty topics now get full-width content with no reserved column (previously the 280px was wasted).
- **Mobile unchanged** — all new controls are `hidden lg:flex`; below `lg` the panels still stack below the content as cards.

## Accessibility

- `aria-expanded` / `aria-controls` on both toggles, pointing at the `#topic-sidebar-panels` region.
- Accessible names contain the visible label (WCAG 2.5.3 *Label in Name*).
- Named complementary landmark (`aria-label="Questions and resources"`) and visible focus rings.
- **Focus management:** focus moves to the now-visible control when toggling, with a guard so focus is *not* stolen on the initial collapsed-by-default mount.

## Tests

28 passing. New coverage for collapse/expand, grid template switching, ARIA wiring, focus management (including no-steal-on-mount), and the empty / questions-only / resources-only sidebar branches.

`TopicDetailPage` and `TopicQuestionsPanel` suites green; `npm run build` and ESLint clean.

## Manual check suggested

Verify in a real browser at `lg` width that the vertical rail text (`writing-mode: vertical-rl`) is legible and the sticky positioning feels right in both light/dark themes — jsdom can't validate CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)