### PR TITLE
fix: stop handle_new_user() inserting into dropped profiles.email column

### DIFF
--- a/supabase/migrations/20260602000000_fix_handle_new_user_drop_email.sql
+++ b/supabase/migrations/20260602000000_fix_handle_new_user_drop_email.sql
@@ -1,0 +1,47 @@
+-- Fix: handle_new_user() must not reference profiles.email.
+--
+-- Regression: migration 20251208191532 dropped profiles.email (PII reduction)
+-- and updated handle_new_user() to stop inserting it. The later migration
+-- 20260526000004_sanitize_display_name_trigger.sql re-created the function from
+-- the ORIGINAL (20251207163731) body, which still inserted into
+-- (id, email, display_name). Since profiles.email no longer exists, every signup
+-- failed in the AFTER INSERT trigger with:
+--   ERROR 42703: column "email" of relation "profiles" does not exist
+-- which aborts the auth.users insert and surfaces as GoTrue 500
+-- "Database error saving new user".
+--
+-- This restores the correct INSERT (id, display_name) while preserving the
+-- display_name sanitization added in 20260526000004.
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  v_raw_name TEXT;
+  v_safe_name TEXT;
+BEGIN
+  v_raw_name := new.raw_user_meta_data ->> 'display_name';
+
+  IF v_raw_name IS NOT NULL THEN
+    -- Pass 1: strip literal HTML tags
+    v_safe_name := regexp_replace(v_raw_name, '<[^>]*>', '', 'g');
+    -- Pass 2: strip numeric/hex character references (&#60; &#x3C; &#X3c; etc.)
+    v_safe_name := regexp_replace(v_safe_name, '&#[xX]?[0-9a-fA-F]+;', '', 'g');
+    -- Pass 3: decode the four common named HTML entities so encoded payloads
+    -- (&lt;script&gt;) can't survive as raw tags after decode
+    v_safe_name := replace(replace(replace(replace(v_safe_name,
+      '&lt;',  '<'),
+      '&gt;',  '>'),
+      '&amp;', '&'),
+      '&quot;', '"');
+    -- Pass 4: strip any tags revealed by entity decode, then cap at 100 chars
+    v_safe_name := left(regexp_replace(v_safe_name, '<[^>]*>', '', 'g'), 100);
+  END IF;
+
+  INSERT INTO public.profiles (id, display_name)
+  VALUES (new.id, v_safe_name);
+  RETURN new;
+END;
+$$;


### PR DESCRIPTION
## Problem

New account creation failed in production with a 500 from `/auth/v1/signup` and the UI error **"Database error saving new user."**

Supabase logs showed the exact cause:

```
42703  column "email" of relation "profiles" does not exist
25P02  current transaction is aborted, commands ignored until end of transaction block
```

On signup, an `AFTER INSERT` trigger on `auth.users` runs `handle_new_user()`, which inserts into `public.profiles`. The function referenced `profiles.email` — a column that no longer exists — so the INSERT threw, the `auth.users` transaction rolled back, and GoTrue returned a 500.

## How it regressed

| Migration | Effect |
|---|---|
| `20251207163731` | Created `profiles` with `email`; trigger inserted `(id, email, display_name)` |
| `20251208191532` | Updated trigger to `(id, display_name)`, then **dropped `email`** (PII reduction) ✅ |
| `20260526000004` (sanitize display_name) | Re-created the function from the original Dec 7 body, **reintroducing the `email` reference** ❌ |

The May 26 sanitization migration was based on the original function body instead of the current one, resurrecting a reference to the long-dropped column.

## Fix

Forward migration `20260602000000_fix_handle_new_user_drop_email.sql` re-creates `handle_new_user()` with the correct `INSERT INTO public.profiles (id, display_name)`, preserving the display_name sanitization added in May. The already-applied bad migration is left untouched.

## Verification

Confirmed in production after applying the migration: account creation succeeds again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)